### PR TITLE
Ensure there is no other wpa supplicants running

### DIFF
--- a/lib/vintage_net/interface/command_runner.ex
+++ b/lib/vintage_net/interface/command_runner.ex
@@ -30,6 +30,11 @@ defmodule VintageNet.Interface.CommandRunner do
     end
   end
 
+  def run({:run_ignore_errors, command, args}) do
+    _ = MuonTrap.cmd(command, args)
+    :ok
+  end
+
   def run({:fun, fun}) do
     fun.()
   end

--- a/lib/vintage_net/interface/raw_config.ex
+++ b/lib/vintage_net/interface/raw_config.ex
@@ -22,7 +22,7 @@ defmodule VintageNet.Interface.RawConfig do
   """
 
   # Should this just be a function??? The down side is that it's less testable since functions are opaque.
-  @type command :: {:run, String.t(), [String.t()]} | {:fun, function()}
+  @type command :: {:run | :run_ignore_errors, String.t(), [String.t()]} | {:fun, function()}
   @type file_contents :: {Path.t(), String.t()}
 
   @enforce_keys [:ifname, :type]

--- a/lib/vintage_net/technology/wifi.ex
+++ b/lib/vintage_net/technology/wifi.ex
@@ -26,6 +26,7 @@ defmodule VintageNet.Technology.WiFi do
     ]
 
     up_cmds = [
+      {:run_ignore_errors, killall, ["-q", "wpa_supplicant"]},
       {:run, wpa_supplicant, ["-B", "-i", ifname, "-c", wpa_supplicant_conf_path, "-dd"]},
       {:run, ifup, ["-i", network_interfaces_path, ifname]}
     ]
@@ -155,7 +156,7 @@ defmodule VintageNet.Technology.WiFi do
       into_config_string(wifi, :mka_ckn),
       into_config_string(wifi, :mka_priority),
 
-      # EAP settings 
+      # EAP settings
       into_config_string(wifi, :identity),
       into_config_string(wifi, :anonymous_identity),
       into_config_string(wifi, :password),

--- a/test/vintage_net/config_wifi_test.exs
+++ b/test/vintage_net/config_wifi_test.exs
@@ -36,6 +36,7 @@ defmodule VintageNet.ConfigWiFiTest do
          """}
       ],
       up_cmds: [
+        {:run_ignore_errors, "/usr/bin/killall", ["-q", "wpa_supplicant"]},
         {:run, "/usr/sbin/wpa_supplicant",
          ["-B", "-i", "wlan0", "-c", "/tmp/vintage_net/wpa_supplicant.conf.wlan0", "-dd"]},
         {:run, "/sbin/ifup", ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]}
@@ -81,6 +82,7 @@ defmodule VintageNet.ConfigWiFiTest do
          """}
       ],
       up_cmds: [
+        {:run_ignore_errors, "/usr/bin/killall", ["-q", "wpa_supplicant"]},
         {:run, "/usr/sbin/wpa_supplicant",
          ["-B", "-i", "wlan0", "-c", "/tmp/vintage_net/wpa_supplicant.conf.wlan0", "-dd"]},
         {:run, "/sbin/ifup", ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]}
@@ -124,6 +126,7 @@ defmodule VintageNet.ConfigWiFiTest do
          """}
       ],
       up_cmds: [
+        {:run_ignore_errors, "/usr/bin/killall", ["-q", "wpa_supplicant"]},
         {:run, "/usr/sbin/wpa_supplicant",
          ["-B", "-i", "wlan0", "-c", "/tmp/vintage_net/wpa_supplicant.conf.wlan0", "-dd"]},
         {:run, "/sbin/ifup", ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]}
@@ -179,6 +182,7 @@ defmodule VintageNet.ConfigWiFiTest do
          """}
       ],
       up_cmds: [
+        {:run_ignore_errors, "/usr/bin/killall", ["-q", "wpa_supplicant"]},
         {:run, "/usr/sbin/wpa_supplicant",
          ["-B", "-i", "wlan0", "-c", "/tmp/vintage_net/wpa_supplicant.conf.wlan0", "-dd"]},
         {:run, "/sbin/ifup", ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]}
@@ -226,6 +230,7 @@ defmodule VintageNet.ConfigWiFiTest do
          """}
       ],
       up_cmds: [
+        {:run_ignore_errors, "/usr/bin/killall", ["-q", "wpa_supplicant"]},
         {:run, "/usr/sbin/wpa_supplicant",
          ["-B", "-i", "wlan0", "-c", "/tmp/vintage_net/wpa_supplicant.conf.wlan0", "-dd"]},
         {:run, "/sbin/ifup", ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]}
@@ -285,6 +290,7 @@ defmodule VintageNet.ConfigWiFiTest do
          """}
       ],
       up_cmds: [
+        {:run_ignore_errors, "/usr/bin/killall", ["-q", "wpa_supplicant"]},
         {:run, "/usr/sbin/wpa_supplicant",
          ["-B", "-i", "wlan0", "-c", "/tmp/vintage_net/wpa_supplicant.conf.wlan0", "-dd"]},
         {:run, "/sbin/ifup", ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]}
@@ -337,6 +343,7 @@ defmodule VintageNet.ConfigWiFiTest do
          """}
       ],
       up_cmds: [
+        {:run_ignore_errors, "/usr/bin/killall", ["-q", "wpa_supplicant"]},
         {:run, "/usr/sbin/wpa_supplicant",
          ["-B", "-i", "wlan0", "-c", "/tmp/vintage_net/wpa_supplicant.conf.wlan0", "-dd"]},
         {:run, "/sbin/ifup", ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]}
@@ -397,6 +404,7 @@ defmodule VintageNet.ConfigWiFiTest do
          """}
       ],
       up_cmds: [
+        {:run_ignore_errors, "/usr/bin/killall", ["-q", "wpa_supplicant"]},
         {:run, "/usr/sbin/wpa_supplicant",
          ["-B", "-i", "wlan0", "-c", "/tmp/vintage_net/wpa_supplicant.conf.wlan0", "-dd"]},
         {:run, "/sbin/ifup", ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]}
@@ -454,6 +462,7 @@ defmodule VintageNet.ConfigWiFiTest do
          """}
       ],
       up_cmds: [
+        {:run_ignore_errors, "/usr/bin/killall", ["-q", "wpa_supplicant"]},
         {:run, "/usr/sbin/wpa_supplicant",
          ["-B", "-i", "wlan0", "-c", "/tmp/vintage_net/wpa_supplicant.conf.wlan0", "-dd"]},
         {:run, "/sbin/ifup", ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]}
@@ -509,6 +518,7 @@ defmodule VintageNet.ConfigWiFiTest do
          """}
       ],
       up_cmds: [
+        {:run_ignore_errors, "/usr/bin/killall", ["-q", "wpa_supplicant"]},
         {:run, "/usr/sbin/wpa_supplicant",
          ["-B", "-i", "wlan0", "-c", "/tmp/vintage_net/wpa_supplicant.conf.wlan0", "-dd"]},
         {:run, "/sbin/ifup", ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]}
@@ -570,6 +580,7 @@ defmodule VintageNet.ConfigWiFiTest do
          """}
       ],
       up_cmds: [
+        {:run_ignore_errors, "/usr/bin/killall", ["-q", "wpa_supplicant"]},
         {:run, "/usr/sbin/wpa_supplicant",
          ["-B", "-i", "wlan0", "-c", "/tmp/vintage_net/wpa_supplicant.conf.wlan0", "-dd"]},
         {:run, "/sbin/ifup", ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]}
@@ -619,6 +630,7 @@ defmodule VintageNet.ConfigWiFiTest do
          """}
       ],
       up_cmds: [
+        {:run_ignore_errors, "/usr/bin/killall", ["-q", "wpa_supplicant"]},
         {:run, "/usr/sbin/wpa_supplicant",
          ["-B", "-i", "wlan0", "-c", "/tmp/vintage_net/wpa_supplicant.conf.wlan0", "-dd"]},
         {:run, "/sbin/ifup", ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]}
@@ -670,6 +682,7 @@ defmodule VintageNet.ConfigWiFiTest do
          """}
       ],
       up_cmds: [
+        {:run_ignore_errors, "/usr/bin/killall", ["-q", "wpa_supplicant"]},
         {:run, "/usr/sbin/wpa_supplicant",
          ["-B", "-i", "wlan0", "-c", "/tmp/vintage_net/wpa_supplicant.conf.wlan0", "-dd"]},
         {:run, "/sbin/ifup", ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]}
@@ -727,6 +740,7 @@ defmodule VintageNet.ConfigWiFiTest do
          """}
       ],
       up_cmds: [
+        {:run_ignore_errors, "/usr/bin/killall", ["-q", "wpa_supplicant"]},
         {:run, "/usr/sbin/wpa_supplicant",
          ["-B", "-i", "wlan0", "-c", "/tmp/vintage_net/wpa_supplicant.conf.wlan0", "-dd"]},
         {:run, "/sbin/ifup", ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]}
@@ -772,6 +786,7 @@ defmodule VintageNet.ConfigWiFiTest do
          """}
       ],
       up_cmds: [
+        {:run_ignore_errors, "/usr/bin/killall", ["-q", "wpa_supplicant"]},
         {:run, "/usr/sbin/wpa_supplicant",
          ["-B", "-i", "wlan0", "-c", "/tmp/vintage_net/wpa_supplicant.conf.wlan0", "-dd"]},
         {:run, "/sbin/ifup", ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]}
@@ -817,6 +832,7 @@ defmodule VintageNet.ConfigWiFiTest do
          """}
       ],
       up_cmds: [
+        {:run_ignore_errors, "/usr/bin/killall", ["-q", "wpa_supplicant"]},
         {:run, "/usr/sbin/wpa_supplicant",
          ["-B", "-i", "wlan0", "-c", "/tmp/vintage_net/wpa_supplicant.conf.wlan0", "-dd"]},
         {:run, "/sbin/ifup", ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]}
@@ -864,6 +880,7 @@ defmodule VintageNet.ConfigWiFiTest do
          """}
       ],
       up_cmds: [
+        {:run_ignore_errors, "/usr/bin/killall", ["-q", "wpa_supplicant"]},
         {:run, "/usr/sbin/wpa_supplicant",
          ["-B", "-i", "wlan0", "-c", "/tmp/vintage_net/wpa_supplicant.conf.wlan0", "-dd"]},
         {:run, "/sbin/ifup", ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]}
@@ -941,6 +958,7 @@ defmodule VintageNet.ConfigWiFiTest do
          """}
       ],
       up_cmds: [
+        {:run_ignore_errors, "/usr/bin/killall", ["-q", "wpa_supplicant"]},
         {:run, "/usr/sbin/wpa_supplicant",
          ["-B", "-i", "wlan0", "-c", "/tmp/vintage_net/wpa_supplicant.conf.wlan0", "-dd"]},
         {:run, "/sbin/ifup", ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]}


### PR DESCRIPTION
When bringing up a WiFi interface we have to ensure that `wpa_supplicant` isn't running. On initial startup, there is no `wpa_supplicant` running so `killall` returns a non zero exit code, but we are okay with that and always just want to run this before trying to start a new `wpa_supplicant` just to make sure.