### PR TITLE
Always obfuscate persistent files

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Project](https://nerves-project.org) devices. It has the following features:
 
 * Ethernet and WiFi support included. Extendible to other technologies
 * Default configurations specified in your Application config
-* Runtime updates to configurations are persisted and applied on next boot (can
-  be disabled)
+* Runtime updates to configurations are persisted and applied on next boot
+  (configurations are obfuscated by default to hide WiFi passphrases)
 * Simple subscription to network status change events
 * Connect to multiple networks at a time and prioritize which interfaces are
   used (Ethernet over WiFi over cellular)
@@ -117,6 +117,7 @@ udhcpc_handler     | Module for handling notifications from `udhcpc`
 resolvconf         | Path to `/etc/resolv.conf`
 persistence        | Module for persisting network configurations
 persistence_dir    | Path to a directory for storing persisted configurations
+persistence_secret | A 16-byte secret or an MFA for getting a secret
 internet_host      | IP address for host to `ping` to check for Internet connectivity
 regulatory_domain  | ISO 3166-1 alpha-2 country (`00` for global, `US`, etc.)
 
@@ -290,8 +291,7 @@ metadata}`
 
 Property               | Values           | Description
  --------------------- | ---------------- | -----------
-`available_interfaces` | `[eth0, ...]`    | The currently available network
-interfaces in priority order. E.g., the first one is used by default
+`available_interfaces` | `[eth0, ...]`    | Currently available network interfaces in priority order. E.g., the first one is used by default
 
 ### Common network interface properties
 

--- a/lib/vintage_net/persistence/flat_file.ex
+++ b/lib/vintage_net/persistence/flat_file.ex
@@ -1,6 +1,18 @@
 defmodule VintageNet.Persistence.FlatFile do
   @behaviour VintageNet.Persistence
 
+  # Version 1 persistence files have the following format:
+  #
+  # Byte offset      Description
+  # 0                Version number - set to 1
+  # 1-16             Initialization vector
+  # 17-32            Authentication tag
+  # 33-              Network config run through :erlang.term_to_binary and
+  #                  encrypted with AES in GCM mode
+  @version 1
+  @mode :aes_gcm
+  @aad "AES256GCM"
+
   @moduledoc """
   Save and load configurations from flat files
   """
@@ -12,7 +24,7 @@ defmodule VintageNet.Persistence.FlatFile do
     File.mkdir_p!(persistence_dir)
 
     Path.join(persistence_dir, ifname)
-    |> File.write(:erlang.term_to_binary(config))
+    |> File.write(serialize_config(config))
   end
 
   @impl true
@@ -20,7 +32,7 @@ defmodule VintageNet.Persistence.FlatFile do
     path = Path.join(persistence_dir(), ifname)
 
     case File.read(path) do
-      {:ok, contents} -> non_raising_binary_to_term(contents)
+      {:ok, contents} -> deserialize_config(contents)
       error -> error
     end
   end
@@ -44,15 +56,64 @@ defmodule VintageNet.Persistence.FlatFile do
     end
   end
 
-  defp persistence_dir() do
-    Application.get_env(:vintage_net, :persistence_dir)
+  defp serialize_config(config) do
+    secret_key = good_secret_key()
+    plaintext = :erlang.term_to_binary(config)
+    iv = :crypto.strong_rand_bytes(16)
+    {ciphertext, tag} = :crypto.block_encrypt(@mode, secret_key, iv, {@aad, plaintext, 16})
+    <<@version, iv::16-bytes, tag::16-bytes, ciphertext::binary>>
   end
+
+  defp deserialize_config(<<@version, iv::16-bytes, tag::16-bytes, ciphertext::binary>>) do
+    secret_key = good_secret_key()
+
+    case :crypto.block_decrypt(:aes_gcm, secret_key, iv, {"AES256GCM", ciphertext, tag}) do
+      :error ->
+        {:error, :decryption_failed}
+
+      plaintext ->
+        non_raising_binary_to_term(plaintext)
+    end
+  end
+
+  defp deserialize_config(_anything_else), do: {:error, :corrupt}
 
   defp non_raising_binary_to_term(bin) do
     try do
       {:ok, :erlang.binary_to_term(bin)}
     catch
       _, _ -> {:error, :corrupt}
+    end
+  end
+
+  defp persistence_dir() do
+    Application.get_env(:vintage_net, :persistence_dir)
+  end
+
+  defp good_secret_key() do
+    case secret_key() do
+      key when is_binary(key) and byte_size(key) == 16 ->
+        key
+
+      _other ->
+        raise RuntimeError, "Secret key for persisting network settings isn't a 16-byte binary"
+    end
+  end
+
+  defp secret_key() do
+    case Application.get_env(:vintage_net, :persistence_secret) do
+      {m, f, a} ->
+        apply(m, f, a)
+
+      f when is_function(f, 0) ->
+        apply(f, [])
+
+      unhidden_key when is_binary(unhidden_key) and byte_size(unhidden_key) == 16 ->
+        unhidden_key
+
+      other ->
+        raise RuntimeError,
+              "Can't use #{inspect(other)} as a secret_key for persisting network settings."
     end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -40,6 +40,7 @@ defmodule VintageNet.MixProject do
         resolvconf: "/etc/resolv.conf",
         persistence: VintageNet.Persistence.FlatFile,
         persistence_dir: "/root/vintage_net",
+        persistence_secret: "obfuscate_things",
         internet_host: "1.1.1.1",
         regulatory_domain: "00"
       ],


### PR DESCRIPTION
At a minimum, this makes it harder to see WiFi passwords. If an MFA is
specified, then it's possible to use a secret that's not hardcoded into
the firmware.