### PR TITLE
Sort local routes first so that they're created before default routes

### DIFF
--- a/lib/vintage_net/route/calculator.ex
+++ b/lib/vintage_net/route/calculator.ex
@@ -46,9 +46,34 @@ defmodule VintageNet.Route.Calculator do
     {new_table_indices, entries} =
       Enum.reduce(infos, {table_indices, []}, &make_entries(&1, &2, prioritization))
 
-    sorted_entries = Enum.sort(entries)
+    sorted_entries = Enum.sort(entries, &sort/2)
 
     {new_table_indices, sorted_entries}
+  end
+
+  # Sort order
+  #
+  # 1. Local routes
+  # 2. Rules
+  # 3. Default routes
+  #
+  # The most important part is that local routes get created before default
+  # routes.  Linux disallows default routes that can't be supported and the
+  # local routes are needed for that.
+  defp sort({:local_route, _, _, _, _} = a, {:local_route, _, _, _, _} = b) do
+    a <= b
+  end
+
+  defp sort({:local_route, _, _, _, _}, _other) do
+    true
+  end
+
+  defp sort(_other, {:local_route, _, _, _, _}) do
+    false
+  end
+
+  defp sort(a, b) do
+    a <= b
   end
 
   @doc """

--- a/test/vintage_net/route/calculator_test.exs
+++ b/test/vintage_net/route/calculator_test.exs
@@ -28,10 +28,10 @@ defmodule VintageNet.Route.CalculatorTest do
 
     assert {%{"eth0" => 100},
             [
+              {:local_route, "eth0", {192, 168, 1, 50}, 24, 10},
               {:rule, 100, {192, 168, 1, 50}},
               {:default_route, "eth0", {192, 168, 1, 1}, 0, 100},
-              {:default_route, "eth0", {192, 168, 1, 1}, 10, :main},
-              {:local_route, "eth0", {192, 168, 1, 50}, 24, 10}
+              {:default_route, "eth0", {192, 168, 1, 1}, 10, :main}
             ]} == Calculator.compute(state, interfaces, prioritization)
   end
 
@@ -65,7 +65,7 @@ defmodule VintageNet.Route.CalculatorTest do
     }
 
     assert {%{"eth0" => 100},
-            [{:rule, 100, {192, 168, 1, 50}}, {:local_route, "eth0", {192, 168, 1, 50}, 24, 50}]} ==
+            [{:local_route, "eth0", {192, 168, 1, 50}, 24, 50}, {:rule, 100, {192, 168, 1, 50}}]} ==
              Calculator.compute(state, interfaces, prioritization)
   end
 
@@ -90,14 +90,14 @@ defmodule VintageNet.Route.CalculatorTest do
 
     assert {%{"eth0" => 100, "wlan0" => 101},
             [
+              {:local_route, "eth0", {192, 168, 1, 50}, 24, 10},
+              {:local_route, "wlan0", {192, 168, 1, 60}, 24, 20},
               {:rule, 100, {192, 168, 1, 50}},
               {:rule, 101, {192, 168, 1, 60}},
               {:default_route, "eth0", {192, 168, 1, 1}, 0, 100},
               {:default_route, "eth0", {192, 168, 1, 1}, 10, :main},
               {:default_route, "wlan0", {192, 168, 1, 1}, 0, 101},
-              {:default_route, "wlan0", {192, 168, 1, 1}, 20, :main},
-              {:local_route, "eth0", {192, 168, 1, 50}, 24, 10},
-              {:local_route, "wlan0", {192, 168, 1, 60}, 24, 20}
+              {:default_route, "wlan0", {192, 168, 1, 1}, 20, :main}
             ]} == Calculator.compute(state, interfaces, prioritization)
   end
 
@@ -122,14 +122,14 @@ defmodule VintageNet.Route.CalculatorTest do
 
     assert {%{"eth0" => 100, "wlan0" => 101},
             [
+              {:local_route, "eth0", {192, 168, 1, 50}, 24, 50},
+              {:local_route, "wlan0", {192, 168, 1, 60}, 24, 20},
               {:rule, 100, {192, 168, 1, 50}},
               {:rule, 101, {192, 168, 1, 60}},
               {:default_route, "eth0", {192, 168, 1, 1}, 0, 100},
               {:default_route, "eth0", {192, 168, 1, 1}, 50, :main},
               {:default_route, "wlan0", {192, 168, 1, 1}, 0, 101},
-              {:default_route, "wlan0", {192, 168, 1, 1}, 20, :main},
-              {:local_route, "eth0", {192, 168, 1, 50}, 24, 50},
-              {:local_route, "wlan0", {192, 168, 1, 60}, 24, 20}
+              {:default_route, "wlan0", {192, 168, 1, 1}, 20, :main}
             ]} == Calculator.compute(state, interfaces, prioritization)
   end
 
@@ -152,12 +152,12 @@ defmodule VintageNet.Route.CalculatorTest do
 
     assert {%{"eth0" => 100},
             [
+              {:local_route, "eth0", {192, 168, 1, 50}, 24, 10},
               {:rule, 100, {192, 168, 1, 50}},
               {:rule, 100, {192, 168, 1, 51}},
               {:rule, 100, {192, 168, 1, 52}},
               {:default_route, "eth0", {192, 168, 1, 1}, 0, 100},
-              {:default_route, "eth0", {192, 168, 1, 1}, 10, :main},
-              {:local_route, "eth0", {192, 168, 1, 50}, 24, 10}
+              {:default_route, "eth0", {192, 168, 1, 1}, 10, :main}
             ]} == Calculator.compute(state, interfaces, prioritization)
   end
 end


### PR DESCRIPTION
This fixes an issue where default route creation failed. The order is now:

1. delete/create local routes
2. delete/create rules
3. delete/create default routes

Deletions warn if they don't delete anything. I haven't seen this yet, but suspect that it might happen. Creates crash if they don't create. That would be unexpected.