### PR TITLE
Fix scanning in hostap mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,11 @@ The `:wifi` key has the following common fields:
 * `:psk` - A WPA2 passphrase or the raw PSK. If a passphrase is passed in, it
   will be converted to a PSK and disgarded.
 * `:ssid` - The SSID for the network
+* `:bgscan` - Periodic background scanning. See the link below for more information.
+  * `:simple`
+  * `{:simple, args}` - args is a string to be passed to the `simple` wpa module
+  * `:learn`
+  * `{:learn, args}` args is a string to be passed to the `learn` wpa module
 
 See the [official
 docs](https://w1.fi/cgit/hostap/plain/wpa_supplicant/wpa_supplicant.conf) for

--- a/test/vintage_net/technology/wifi_test.exs
+++ b/test/vintage_net/technology/wifi_test.exs
@@ -1049,6 +1049,9 @@ defmodule VintageNet.Technology.WiFiTest do
       wifi: %{
         ssid: "example ap",
         key_mgmt: :none,
+        scan_ssid: 1,
+        ap_scan: 1,
+        bgscan: :simple,
         mode: :host
       },
       ipv4: %{
@@ -1082,9 +1085,12 @@ defmodule VintageNet.Technology.WiFiTest do
          """
          ctrl_interface=/tmp/vintage_net/wpa_supplicant
          country=00
+         bgscan="simple"
+         ap_scan=1
          network={
          ssid="example ap"
          key_mgmt=NONE
+         scan_ssid=1
          mode=2
          }
          """},


### PR DESCRIPTION
when starting wpa_supplicant in `host` mode, it creates a `p2p_dev_wlan0` ctrl_interface instead of the standard `wlan0` ctrl_interface. The `scan` ioctl will now check for both of those files and use them rather than always trying to use the standard `wlan0` ctrl_interface. 

This also adds the ability to use `bgscan` which will periodically scan for ssids in the background. This is required because the `scan` command to `wpa_cli` is ignored while in `host` mode.  