### PR TITLE
Fix LAN routing when policy-based tables were being used

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,6 @@ jobs:
         environment:
           ELIXIR_VERSION: 1.7.4-otp-21
           LC_ALL: C.UTF-8
-          SUDO: true
     <<: *defaults
     steps:
       - checkout

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@
 # ERL_LDFLAGS	additional linker flags for projects referencing Erlang libraries
 
 ifeq ($(MIX_COMPILE_PATH),)
-call_from_mix:
+call_from_make:
 	mix compile
 endif
 
@@ -52,9 +52,6 @@ CC ?= $(CROSSCOMPILE)-gcc
 # CFLAGS += -DDEBUG
 
 CFLAGS += -std=gnu99
-
-calling_from_make:
-	mix compile
 
 all: install
 

--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ iex> VintageNet.configure("wlan0", %{
 networking information:
 
 ```elixir
-iex> VintageNet.get(["interface", "eth0", :connection])
+iex> VintageNet.get(["interface", "eth0", "connection"])
 :internet
 
 iex> VintageNet.get_by_prefix([])

--- a/lib/vintage_net/route/calculator.ex
+++ b/lib/vintage_net/route/calculator.ex
@@ -55,27 +55,25 @@ defmodule VintageNet.Route.Calculator do
 
   # Sort order
   #
-  # 1. Local routes
-  # 2. Rules
+  # 1. Rules
+  # 2. Local routes
   # 3. Default routes
   #
   # The most important part is that local routes get created before default
   # routes.  Linux disallows default routes that can't be supported and the
   # local routes are needed for that.
-  defp sort({:local_route, _, _, _, _} = a, {:local_route, _, _, _, _} = b) do
+  defp sort_priority(:rule), do: 0
+  defp sort_priority(:local_route), do: 1
+  defp sort_priority(:default_route), do: 2
+
+  defp sort(a, b) when elem(a, 0) == elem(b, 0) do
     a <= b
-  end
-
-  defp sort({:local_route, _, _, _, _}, _other) do
-    true
-  end
-
-  defp sort(_other, {:local_route, _, _, _, _}) do
-    false
   end
 
   defp sort(a, b) do
-    a <= b
+    priority_a = elem(a, 0) |> sort_priority()
+    priority_b = elem(b, 0) |> sort_priority()
+    priority_a <= priority_b
   end
 
   @doc """
@@ -112,7 +110,8 @@ defmodule VintageNet.Route.Calculator do
         {ip, subnet_bits} = hd(info.ip_subnets)
 
         [
-          {:local_route, ifname, ip, subnet_bits, metric}
+          {:local_route, ifname, ip, subnet_bits, 0, table_index},
+          {:local_route, ifname, ip, subnet_bits, metric, :main}
         ]
       else
         []

--- a/lib/vintage_net/route_manager.ex
+++ b/lib/vintage_net/route_manager.ex
@@ -220,8 +220,8 @@ defmodule VintageNet.RouteManager do
     |> warn_on_error("clear_a_route")
   end
 
-  defp handle_delete({:local_route, ifname, address, subnet_bits, metric}) do
-    IPRoute.clear_a_local_route(ifname, address, subnet_bits, metric)
+  defp handle_delete({:local_route, ifname, address, subnet_bits, metric, table_index}) do
+    IPRoute.clear_a_local_route(ifname, address, subnet_bits, metric, table_index)
     |> warn_on_error("clear_a_local_route")
   end
 
@@ -238,11 +238,14 @@ defmodule VintageNet.RouteManager do
     :ok = IPRoute.add_rule(address, table_index)
   end
 
-  defp handle_insert({:local_route, ifname, address, subnet_bits, metric}) do
-    # HACK: Delete automatically created local routes that have a 0 metric
-    _ = IPRoute.clear_a_local_route(ifname, address, subnet_bits, 0)
+  defp handle_insert({:local_route, ifname, address, subnet_bits, metric, table_index}) do
+    if table_index == :main do
+      # HACK: Delete automatically created local routes that have a 0 metric
+      _ = IPRoute.clear_a_local_route(ifname, address, subnet_bits, 0, :main)
+      :ok
+    end
 
-    :ok = IPRoute.add_local_route(ifname, address, subnet_bits, metric)
+    :ok = IPRoute.add_local_route(ifname, address, subnet_bits, metric, table_index)
   end
 
   defp warn_on_error(:ok, _label), do: :ok

--- a/test/vintage_net/route/calculator_test.exs
+++ b/test/vintage_net/route/calculator_test.exs
@@ -28,8 +28,9 @@ defmodule VintageNet.Route.CalculatorTest do
 
     assert {%{"eth0" => 100},
             [
-              {:local_route, "eth0", {192, 168, 1, 50}, 24, 10},
               {:rule, 100, {192, 168, 1, 50}},
+              {:local_route, "eth0", {192, 168, 1, 50}, 24, 0, 100},
+              {:local_route, "eth0", {192, 168, 1, 50}, 24, 10, :main},
               {:default_route, "eth0", {192, 168, 1, 1}, 0, 100},
               {:default_route, "eth0", {192, 168, 1, 1}, 10, :main}
             ]} == Calculator.compute(state, interfaces, prioritization)
@@ -65,7 +66,11 @@ defmodule VintageNet.Route.CalculatorTest do
     }
 
     assert {%{"eth0" => 100},
-            [{:local_route, "eth0", {192, 168, 1, 50}, 24, 50}, {:rule, 100, {192, 168, 1, 50}}]} ==
+            [
+              {:rule, 100, {192, 168, 1, 50}},
+              {:local_route, "eth0", {192, 168, 1, 50}, 24, 0, 100},
+              {:local_route, "eth0", {192, 168, 1, 50}, 24, 50, :main}
+            ]} ==
              Calculator.compute(state, interfaces, prioritization)
   end
 
@@ -90,10 +95,12 @@ defmodule VintageNet.Route.CalculatorTest do
 
     assert {%{"eth0" => 100, "wlan0" => 101},
             [
-              {:local_route, "eth0", {192, 168, 1, 50}, 24, 10},
-              {:local_route, "wlan0", {192, 168, 1, 60}, 24, 20},
               {:rule, 100, {192, 168, 1, 50}},
               {:rule, 101, {192, 168, 1, 60}},
+              {:local_route, "eth0", {192, 168, 1, 50}, 24, 0, 100},
+              {:local_route, "eth0", {192, 168, 1, 50}, 24, 10, :main},
+              {:local_route, "wlan0", {192, 168, 1, 60}, 24, 0, 101},
+              {:local_route, "wlan0", {192, 168, 1, 60}, 24, 20, :main},
               {:default_route, "eth0", {192, 168, 1, 1}, 0, 100},
               {:default_route, "eth0", {192, 168, 1, 1}, 10, :main},
               {:default_route, "wlan0", {192, 168, 1, 1}, 0, 101},
@@ -122,10 +129,12 @@ defmodule VintageNet.Route.CalculatorTest do
 
     assert {%{"eth0" => 100, "wlan0" => 101},
             [
-              {:local_route, "eth0", {192, 168, 1, 50}, 24, 50},
-              {:local_route, "wlan0", {192, 168, 1, 60}, 24, 20},
               {:rule, 100, {192, 168, 1, 50}},
               {:rule, 101, {192, 168, 1, 60}},
+              {:local_route, "eth0", {192, 168, 1, 50}, 24, 0, 100},
+              {:local_route, "eth0", {192, 168, 1, 50}, 24, 50, :main},
+              {:local_route, "wlan0", {192, 168, 1, 60}, 24, 0, 101},
+              {:local_route, "wlan0", {192, 168, 1, 60}, 24, 20, :main},
               {:default_route, "eth0", {192, 168, 1, 1}, 0, 100},
               {:default_route, "eth0", {192, 168, 1, 1}, 50, :main},
               {:default_route, "wlan0", {192, 168, 1, 1}, 0, 101},
@@ -152,10 +161,11 @@ defmodule VintageNet.Route.CalculatorTest do
 
     assert {%{"eth0" => 100},
             [
-              {:local_route, "eth0", {192, 168, 1, 50}, 24, 10},
               {:rule, 100, {192, 168, 1, 50}},
               {:rule, 100, {192, 168, 1, 51}},
               {:rule, 100, {192, 168, 1, 52}},
+              {:local_route, "eth0", {192, 168, 1, 50}, 24, 0, 100},
+              {:local_route, "eth0", {192, 168, 1, 50}, 24, 10, :main},
               {:default_route, "eth0", {192, 168, 1, 1}, 0, 100},
               {:default_route, "eth0", {192, 168, 1, 1}, 10, :main}
             ]} == Calculator.compute(state, interfaces, prioritization)


### PR DESCRIPTION
This affected incoming pings and connections from devices on LANs. It looked like it worked on many people's LANs before this change, but if you inspected the packets in this scenario, you'd see that the LAN's router was fixing things up.