### PR TITLE
Various small fixes

### DIFF
--- a/lib/vintage_net/application.ex
+++ b/lib/vintage_net/application.ex
@@ -19,7 +19,7 @@ defmodule VintageNet.Application do
       VintageNet.InterfacesSupervisor
     ]
 
-    opts = [strategy: :one_for_one, name: VintageNet.Supervisor]
+    opts = [strategy: :rest_for_one, name: VintageNet.Supervisor]
     Supervisor.start_link(children, opts)
   end
 end

--- a/lib/vintage_net/interface.ex
+++ b/lib/vintage_net/interface.ex
@@ -633,7 +633,7 @@ defmodule VintageNet.Interface do
 
   @impl true
   def handle_event({:call, from}, :get_configuration, _state, data) do
-    {:reply, from, data.config.source_config}
+    {:keep_state, data, {:reply, from, data.config.source_config}}
   end
 
   @impl true

--- a/lib/vintage_net/interface.ex
+++ b/lib/vintage_net/interface.ex
@@ -696,6 +696,13 @@ defmodule VintageNet.Interface do
 
     PropertyTable.put(VintageNet, ["interface", ifname, "type"], config.type)
     PropertyTable.put(VintageNet, ["interface", ifname, "state"], state)
+
+    if state != :configured do
+      # Once a state is `:configured`, then the configuration provides the connection
+      # status. When not configured, report it as `:disconnected` to avoid any confusion
+      # with stale or unset values.
+      PropertyTable.put(VintageNet, ["interface", ifname, "connection"], :disconnected)
+    end
   end
 
   defp run_ioctl(data, from, mfa) do

--- a/lib/vintage_net/interface/classification.ex
+++ b/lib/vintage_net/interface/classification.ex
@@ -66,9 +66,9 @@ defmodule VintageNet.Interface.Classification do
   """
   @spec compute_metric(interface_type(), connection_status(), [prioritization()]) ::
           pos_integer() | :disabled
-  def compute_metric(_type, :disabled, _prioritization), do: :disabled
+  def compute_metric(_type, :disconnected, _prioritization), do: :disabled
 
-  def compute_metric(type, status, prioritization) when is_atom(type) do
+  def compute_metric(type, status, prioritization) when status in [:lan, :internet] do
     case Enum.find_index(prioritization, fn option -> matches_option?(option, type, status) end) do
       nil ->
         :disabled

--- a/lib/vintage_net/route/calculator.ex
+++ b/lib/vintage_net/route/calculator.ex
@@ -98,6 +98,17 @@ defmodule VintageNet.Route.Calculator do
   defp make_entries({ifname, info}, {table_indices, entries}, prioritization) do
     {new_table_indices, table_index} = get_table_index(ifname, table_indices)
     metric = InterfaceInfo.metric(info, prioritization)
+
+    new_entries = routing_table_entries(metric, ifname, table_index, info)
+
+    {new_table_indices, new_entries ++ entries}
+  end
+
+  defp routing_table_entries(:disabled, _ifname, _table_index, _info) do
+    []
+  end
+
+  defp routing_table_entries(metric, ifname, table_index, info) do
     # Every package with a source IP address of this interface needs to using
     # routing table "table_index"
     rules = for {ip, _subnet} <- info.ip_subnets, do: {:rule, table_index, ip}
@@ -131,7 +142,7 @@ defmodule VintageNet.Route.Calculator do
         []
       end
 
-    {new_table_indices, rules ++ local_routes ++ tables ++ entries}
+    rules ++ local_routes ++ tables
   end
 
   defp get_table_index(ifname, table_indices) do

--- a/lib/vintage_net/route/ip_route.ex
+++ b/lib/vintage_net/route/ip_route.ex
@@ -17,7 +17,7 @@ defmodule VintageNet.Route.IPRoute do
           Calculator.table_index()
         ) ::
           :ok | {:error, any()}
-  def add_default_route(ifname, route, metric, table_index) do
+  def add_default_route(ifname, route, metric, table_index) when is_integer(metric) do
     table_index_string = table_index_to_string(table_index)
 
     ip_cmd([
@@ -27,7 +27,7 @@ defmodule VintageNet.Route.IPRoute do
       "table",
       table_index_string,
       "metric",
-      "#{metric}",
+      to_string(metric),
       "via",
       ip_to_string(route),
       "dev",
@@ -46,7 +46,7 @@ defmodule VintageNet.Route.IPRoute do
           Calculator.table_index()
         ) ::
           :ok | {:error, any()}
-  def add_local_route(ifname, ip, subnet_bits, metric, table_index) do
+  def add_local_route(ifname, ip, subnet_bits, metric, table_index) when is_integer(metric) do
     subnet = Calculator.to_subnet(ip, subnet_bits)
     subnet_string = ip_to_string(subnet) <> "/" <> to_string(subnet_bits)
     table_index_string = table_index_to_string(table_index)
@@ -129,7 +129,7 @@ defmodule VintageNet.Route.IPRoute do
           Calculator.table_index()
         ) ::
           :ok | {:error, any()}
-  def clear_a_local_route(ifname, ip, subnet_bits, metric, table_index) do
+  def clear_a_local_route(ifname, ip, subnet_bits, metric, table_index) when is_integer(metric) do
     subnet = Calculator.to_subnet(ip, subnet_bits)
     subnet_string = ip_to_string(subnet) <> "/" <> to_string(subnet_bits)
     table_index_string = table_index_to_string(table_index)
@@ -141,7 +141,7 @@ defmodule VintageNet.Route.IPRoute do
       "table",
       table_index_string,
       "metric",
-      "#{metric}",
+      to_string(metric),
       "dev",
       ifname,
       "scope",

--- a/lib/vintage_net/route/properties.ex
+++ b/lib/vintage_net/route/properties.ex
@@ -54,7 +54,7 @@ defmodule VintageNet.Route.Properties do
   defp status_to_priority(:internet), do: 2
 
   defp local_routes(routes) do
-    for {:local_route, ifname, _address, _subnet_bits, metric} <- routes,
+    for {:local_route, ifname, _address, _subnet_bits, metric, :main} <- routes,
         do: {metric, ifname}
   end
 end

--- a/lib/vintage_net/technology.ex
+++ b/lib/vintage_net/technology.ex
@@ -9,6 +9,14 @@ defmodule VintageNet.Technology do
   """
 
   @doc """
+  Normalize a configuration
+
+  Technologies can use this to update provided configurations so that same configurations that could
+  be specified in multiple ways have a single representation.
+  """
+  @callback normalize(config :: map()) :: {:ok, map()} | {:error, any()}
+
+  @doc """
   Convert a technology-specific configuration to one for VintageNet
   """
   @callback to_raw_config(VintageNet.ifname(), config :: map(), opts :: keyword()) ::

--- a/lib/vintage_net/technology/ethernet.ex
+++ b/lib/vintage_net/technology/ethernet.ex
@@ -5,6 +5,9 @@ defmodule VintageNet.Technology.Ethernet do
   alias VintageNet.IP.ConfigToInterfaces
 
   @impl true
+  def normalize(%{type: __MODULE__} = config), do: {:ok, config}
+
+  @impl true
   def to_raw_config(ifname, %{type: __MODULE__} = config, opts) do
     ifup = Keyword.fetch!(opts, :bin_ifup)
     ifdown = Keyword.fetch!(opts, :bin_ifdown)

--- a/lib/vintage_net/technology/ethernet.ex
+++ b/lib/vintage_net/technology/ethernet.ex
@@ -27,7 +27,10 @@ defmodule VintageNet.Technology.Ethernet do
        child_specs: [{VintageNet.Interface.ConnectivityChecker, ifname}],
        # ifup hangs forever until Ethernet is plugged in
        up_cmd_millis: 60_000,
-       up_cmds: [{:run, ifup, ["-i", network_interfaces_path, ifname]}],
+       up_cmds: [
+         {:run_ignore_errors, ifdown, ["-i", network_interfaces_path, ifname]},
+         {:run, ifup, ["-i", network_interfaces_path, ifname]}
+       ],
        down_cmd_millis: 5_000,
        down_cmds: [{:run, ifdown, ["-i", network_interfaces_path, ifname]}]
      }}

--- a/lib/vintage_net/technology/mobile.ex
+++ b/lib/vintage_net/technology/mobile.ex
@@ -4,6 +4,9 @@ defmodule VintageNet.Technology.Mobile do
   alias VintageNet.Interface.RawConfig
 
   @impl true
+  def normalize(%{type: __MODULE__} = config), do: {:ok, config}
+
+  @impl true
   def to_raw_config(ifname, %{type: __MODULE__, pppd: pppd_config} = config, opts) do
     mknod = Keyword.fetch!(opts, :bin_mknod)
     killall = Keyword.fetch!(opts, :bin_killall)

--- a/lib/vintage_net/technology/null.ex
+++ b/lib/vintage_net/technology/null.ex
@@ -3,16 +3,22 @@ defmodule VintageNet.Technology.Null do
 
   alias VintageNet.Interface.RawConfig
 
+  @null_config %{type: __MODULE__}
+
   @moduledoc """
   An interface with this technology is unconfigured
   """
+
+  @impl true
+  def normalize(_config), do: {:ok, @null_config}
+
   @impl true
   def to_raw_config(ifname, _config \\ %{}, _opts \\ []) do
     {:ok,
      %RawConfig{
        ifname: ifname,
        type: __MODULE__,
-       source_config: %{type: __MODULE__},
+       source_config: @null_config,
        require_interface: false
      }}
   end

--- a/lib/vintage_net/technology/wifi.ex
+++ b/lib/vintage_net/technology/wifi.ex
@@ -41,6 +41,7 @@ defmodule VintageNet.Technology.WiFi do
     ]
 
     up_cmds = [
+      {:run_ignore_errors, ifdown, ["-i", network_interfaces_path, ifname]},
       {:run_ignore_errors, killall, ["-q", "wpa_supplicant"]},
       {:run, wpa_supplicant, ["-B", "-i", ifname, "-c", wpa_supplicant_conf_path, "-dd"]},
       {:run, ifup, ["-i", network_interfaces_path, ifname]}

--- a/lib/vintage_net/technology/wifi.ex
+++ b/lib/vintage_net/technology/wifi.ex
@@ -46,6 +46,7 @@ defmodule VintageNet.Technology.WiFi do
            cleanup_files: [Path.join(control_interface_path, ifname)],
            child_specs: [{VintageNet.Interface.ConnectivityChecker, ifname}],
            up_cmds: up_cmds ++ udhcpd_up_cmds,
+           up_cmd_millis: 60_000,
            down_cmds: down_cmds ++ udhcpd_down_cmds
          }}
 
@@ -59,6 +60,7 @@ defmodule VintageNet.Technology.WiFi do
            cleanup_files: [Path.join(control_interface_path, ifname)],
            child_specs: [{VintageNet.Interface.ConnectivityChecker, ifname}],
            up_cmds: up_cmds,
+           up_cmd_millis: 60_000,
            down_cmds: down_cmds
          }}
     end

--- a/lib/vintage_net/wifi/wpa2.ex
+++ b/lib/vintage_net/wifi/wpa2.ex
@@ -27,7 +27,7 @@ defmodule VintageNet.WiFi.WPA2 do
     end
   end
 
-  def to_psk(ssid, passphrase) do
+  def to_psk(ssid, passphrase) when is_binary(passphrase) do
     with :ok <- password_ok(passphrase),
          :ok <- ssid_ok(ssid) do
       {:ok, compute_psk(ssid, passphrase)}

--- a/test/vintage_net/interface/connectivity_checker_test.exs
+++ b/test/vintage_net/interface/connectivity_checker_test.exs
@@ -4,20 +4,20 @@ defmodule VintageNet.Interface.ConnectivityCheckerTest do
   alias VintageNet.Interface.ConnectivityChecker
 
   test "disconnected interface" do
-    start_supervised!({ConnectivityChecker, "disconnected_interface"})
-
     property = ["interface", "disconnected_interface", "connection"]
     VintageNet.subscribe(property)
+
+    start_supervised!({ConnectivityChecker, "disconnected_interface"})
 
     assert_receive {VintageNet, property, _old_value, :disconnected, _meta}, 1_000
   end
 
   test "internet connected interface" do
     ifname = get_ifname()
-    start_supervised!({ConnectivityChecker, ifname})
-
     property = ["interface", ifname, "connection"]
     VintageNet.subscribe(property)
+
+    start_supervised!({ConnectivityChecker, ifname})
 
     assert_receive {VintageNet, property, _old_value, :internet, _meta}, 1_000
   end

--- a/test/vintage_net/interface_test.exs
+++ b/test/vintage_net/interface_test.exs
@@ -38,6 +38,15 @@ defmodule VintageNet.InterfaceTest do
     end)
   end
 
+  test "getting the configuration", context do
+    in_tmp(context.test, fn ->
+      {:ok, raw_config} = VintageNet.Technology.Null.to_raw_config(@ifname)
+      start_and_configure(raw_config)
+
+      assert %{type: VintageNet.Technology.Null} == VintageNet.get_configuration(@ifname)
+    end)
+  end
+
   test "creates and deletes files", context do
     in_tmp(context.test, fn ->
       raw_config = %RawConfig{

--- a/test/vintage_net/route/calculator_test.exs
+++ b/test/vintage_net/route/calculator_test.exs
@@ -36,6 +36,24 @@ defmodule VintageNet.Route.CalculatorTest do
             ]} == Calculator.compute(state, interfaces, prioritization)
   end
 
+  test "a disconnected interface" do
+    prioritization = Classification.default_prioritization()
+    state = Calculator.init()
+
+    # The calculator should ignore the IP address and gateway even
+    # if they're present.
+    interfaces = %{
+      "eth0" => %InterfaceInfo{
+        interface_type: :ethernet,
+        status: :disconnected,
+        ip_subnets: [{{192, 168, 1, 50}, 24}],
+        default_gateway: {192, 168, 1, 1}
+      }
+    }
+
+    assert {%{"eth0" => 100}, []} == Calculator.compute(state, interfaces, prioritization)
+  end
+
   test "interface w/o addresses" do
     prioritization = Classification.default_prioritization()
     state = Calculator.init()

--- a/test/vintage_net/route/properties_test.exs
+++ b/test/vintage_net/route/properties_test.exs
@@ -18,10 +18,12 @@ defmodule VintageNet.Route.PropertiesTest do
 
   test "orders available_interface by metric" do
     routes = [
-      {:local_route, "eth0", {192, 168, 1, 50}, 24, 10},
-      {:local_route, "wlan0", {192, 168, 1, 60}, 24, 20},
       {:rule, 100, {192, 168, 1, 50}},
       {:rule, 101, {192, 168, 1, 60}},
+      {:local_route, "eth0", {192, 168, 1, 50}, 24, 0, 100},
+      {:local_route, "eth0", {192, 168, 1, 50}, 24, 10, :main},
+      {:local_route, "wlan0", {192, 168, 1, 60}, 24, 0, 101},
+      {:local_route, "wlan0", {192, 168, 1, 60}, 24, 20, :main},
       {:default_route, "eth0", {192, 168, 1, 1}, 0, 100},
       {:default_route, "eth0", {192, 168, 1, 1}, 10, :main},
       {:default_route, "wlan0", {192, 168, 1, 1}, 0, 101},
@@ -30,15 +32,17 @@ defmodule VintageNet.Route.PropertiesTest do
 
     :ok = Properties.update_available_interfaces(routes)
 
-    assert ["eth0", "wlan0"] = VintageNet.get(["available_interfaces"])
+    assert ["eth0", "wlan0"] == VintageNet.get(["available_interfaces"])
   end
 
   test "orders available_interface by metric 2" do
     routes = [
-      {:local_route, "eth0", {192, 168, 1, 50}, 24, 50},
-      {:local_route, "wlan0", {192, 168, 1, 60}, 24, 20},
       {:rule, 100, {192, 168, 1, 50}},
       {:rule, 101, {192, 168, 1, 60}},
+      {:local_route, "eth0", {192, 168, 1, 50}, 24, 0, 100},
+      {:local_route, "eth0", {192, 168, 1, 50}, 24, 50, :main},
+      {:local_route, "wlan0", {192, 168, 1, 60}, 24, 0, 101},
+      {:local_route, "wlan0", {192, 168, 1, 60}, 24, 20, :main},
       {:default_route, "eth0", {192, 168, 1, 1}, 0, 100},
       {:default_route, "eth0", {192, 168, 1, 1}, 50, :main},
       {:default_route, "wlan0", {192, 168, 1, 1}, 0, 101},
@@ -47,7 +51,7 @@ defmodule VintageNet.Route.PropertiesTest do
 
     :ok = Properties.update_available_interfaces(routes)
 
-    assert ["wlan0", "eth0"] = VintageNet.get(["available_interfaces"])
+    assert ["wlan0", "eth0"] == VintageNet.get(["available_interfaces"])
   end
 
   test "updates best connection" do

--- a/test/vintage_net/technology/ethernet_test.exs
+++ b/test/vintage_net/technology/ethernet_test.exs
@@ -16,7 +16,11 @@ defmodule VintageNet.Technology.EthernetTest do
         {"/tmp/vintage_net/network_interfaces.eth0", dhcp_interface("eth0", "unittest")}
       ],
       up_cmd_millis: 60_000,
-      up_cmds: [{:run, "/sbin/ifup", ["-i", "/tmp/vintage_net/network_interfaces.eth0", "eth0"]}],
+      up_cmds: [
+        {:run_ignore_errors, "/sbin/ifdown",
+         ["-i", "/tmp/vintage_net/network_interfaces.eth0", "eth0"]},
+        {:run, "/sbin/ifup", ["-i", "/tmp/vintage_net/network_interfaces.eth0", "eth0"]}
+      ],
       down_cmds: [
         {:run, "/sbin/ifdown", ["-i", "/tmp/vintage_net/network_interfaces.eth0", "eth0"]}
       ]
@@ -52,7 +56,11 @@ defmodule VintageNet.Technology.EthernetTest do
       child_specs: [{VintageNet.Interface.ConnectivityChecker, "eth0"}],
       files: [{"/tmp/vintage_net/network_interfaces.eth0", interfaces_content}],
       up_cmd_millis: 60_000,
-      up_cmds: [{:run, "/sbin/ifup", ["-i", "/tmp/vintage_net/network_interfaces.eth0", "eth0"]}],
+      up_cmds: [
+        {:run_ignore_errors, "/sbin/ifdown",
+         ["-i", "/tmp/vintage_net/network_interfaces.eth0", "eth0"]},
+        {:run, "/sbin/ifup", ["-i", "/tmp/vintage_net/network_interfaces.eth0", "eth0"]}
+      ],
       down_cmds: [
         {:run, "/sbin/ifdown", ["-i", "/tmp/vintage_net/network_interfaces.eth0", "eth0"]}
       ]

--- a/test/vintage_net/technology/wifi_test.exs
+++ b/test/vintage_net/technology/wifi_test.exs
@@ -64,6 +64,8 @@ defmodule VintageNet.Technology.WiFiTest do
       ],
       up_cmd_millis: 60_000,
       up_cmds: [
+        {:run_ignore_errors, "/sbin/ifdown",
+         ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]},
         {:run_ignore_errors, "/usr/bin/killall", ["-q", "wpa_supplicant"]},
         {:run, "/usr/sbin/wpa_supplicant",
          ["-B", "-i", "wlan0", "-c", "/tmp/vintage_net/wpa_supplicant.conf.wlan0", "-dd"]},
@@ -111,6 +113,8 @@ defmodule VintageNet.Technology.WiFiTest do
       ],
       up_cmd_millis: 60_000,
       up_cmds: [
+        {:run_ignore_errors, "/sbin/ifdown",
+         ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]},
         {:run_ignore_errors, "/usr/bin/killall", ["-q", "wpa_supplicant"]},
         {:run, "/usr/sbin/wpa_supplicant",
          ["-B", "-i", "wlan0", "-c", "/tmp/vintage_net/wpa_supplicant.conf.wlan0", "-dd"]},
@@ -156,6 +160,8 @@ defmodule VintageNet.Technology.WiFiTest do
       ],
       up_cmd_millis: 60_000,
       up_cmds: [
+        {:run_ignore_errors, "/sbin/ifdown",
+         ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]},
         {:run_ignore_errors, "/usr/bin/killall", ["-q", "wpa_supplicant"]},
         {:run, "/usr/sbin/wpa_supplicant",
          ["-B", "-i", "wlan0", "-c", "/tmp/vintage_net/wpa_supplicant.conf.wlan0", "-dd"]},
@@ -213,6 +219,8 @@ defmodule VintageNet.Technology.WiFiTest do
       ],
       up_cmd_millis: 60_000,
       up_cmds: [
+        {:run_ignore_errors, "/sbin/ifdown",
+         ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]},
         {:run_ignore_errors, "/usr/bin/killall", ["-q", "wpa_supplicant"]},
         {:run, "/usr/sbin/wpa_supplicant",
          ["-B", "-i", "wlan0", "-c", "/tmp/vintage_net/wpa_supplicant.conf.wlan0", "-dd"]},
@@ -262,6 +270,8 @@ defmodule VintageNet.Technology.WiFiTest do
       ],
       up_cmd_millis: 60_000,
       up_cmds: [
+        {:run_ignore_errors, "/sbin/ifdown",
+         ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]},
         {:run_ignore_errors, "/usr/bin/killall", ["-q", "wpa_supplicant"]},
         {:run, "/usr/sbin/wpa_supplicant",
          ["-B", "-i", "wlan0", "-c", "/tmp/vintage_net/wpa_supplicant.conf.wlan0", "-dd"]},
@@ -323,6 +333,8 @@ defmodule VintageNet.Technology.WiFiTest do
       ],
       up_cmd_millis: 60_000,
       up_cmds: [
+        {:run_ignore_errors, "/sbin/ifdown",
+         ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]},
         {:run_ignore_errors, "/usr/bin/killall", ["-q", "wpa_supplicant"]},
         {:run, "/usr/sbin/wpa_supplicant",
          ["-B", "-i", "wlan0", "-c", "/tmp/vintage_net/wpa_supplicant.conf.wlan0", "-dd"]},
@@ -377,6 +389,8 @@ defmodule VintageNet.Technology.WiFiTest do
       ],
       up_cmd_millis: 60_000,
       up_cmds: [
+        {:run_ignore_errors, "/sbin/ifdown",
+         ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]},
         {:run_ignore_errors, "/usr/bin/killall", ["-q", "wpa_supplicant"]},
         {:run, "/usr/sbin/wpa_supplicant",
          ["-B", "-i", "wlan0", "-c", "/tmp/vintage_net/wpa_supplicant.conf.wlan0", "-dd"]},
@@ -439,6 +453,8 @@ defmodule VintageNet.Technology.WiFiTest do
       ],
       up_cmd_millis: 60_000,
       up_cmds: [
+        {:run_ignore_errors, "/sbin/ifdown",
+         ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]},
         {:run_ignore_errors, "/usr/bin/killall", ["-q", "wpa_supplicant"]},
         {:run, "/usr/sbin/wpa_supplicant",
          ["-B", "-i", "wlan0", "-c", "/tmp/vintage_net/wpa_supplicant.conf.wlan0", "-dd"]},
@@ -498,6 +514,8 @@ defmodule VintageNet.Technology.WiFiTest do
       ],
       up_cmd_millis: 60_000,
       up_cmds: [
+        {:run_ignore_errors, "/sbin/ifdown",
+         ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]},
         {:run_ignore_errors, "/usr/bin/killall", ["-q", "wpa_supplicant"]},
         {:run, "/usr/sbin/wpa_supplicant",
          ["-B", "-i", "wlan0", "-c", "/tmp/vintage_net/wpa_supplicant.conf.wlan0", "-dd"]},
@@ -555,6 +573,8 @@ defmodule VintageNet.Technology.WiFiTest do
       ],
       up_cmd_millis: 60_000,
       up_cmds: [
+        {:run_ignore_errors, "/sbin/ifdown",
+         ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]},
         {:run_ignore_errors, "/usr/bin/killall", ["-q", "wpa_supplicant"]},
         {:run, "/usr/sbin/wpa_supplicant",
          ["-B", "-i", "wlan0", "-c", "/tmp/vintage_net/wpa_supplicant.conf.wlan0", "-dd"]},
@@ -618,6 +638,8 @@ defmodule VintageNet.Technology.WiFiTest do
       ],
       up_cmd_millis: 60_000,
       up_cmds: [
+        {:run_ignore_errors, "/sbin/ifdown",
+         ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]},
         {:run_ignore_errors, "/usr/bin/killall", ["-q", "wpa_supplicant"]},
         {:run, "/usr/sbin/wpa_supplicant",
          ["-B", "-i", "wlan0", "-c", "/tmp/vintage_net/wpa_supplicant.conf.wlan0", "-dd"]},
@@ -669,6 +691,8 @@ defmodule VintageNet.Technology.WiFiTest do
       ],
       up_cmd_millis: 60_000,
       up_cmds: [
+        {:run_ignore_errors, "/sbin/ifdown",
+         ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]},
         {:run_ignore_errors, "/usr/bin/killall", ["-q", "wpa_supplicant"]},
         {:run, "/usr/sbin/wpa_supplicant",
          ["-B", "-i", "wlan0", "-c", "/tmp/vintage_net/wpa_supplicant.conf.wlan0", "-dd"]},
@@ -722,6 +746,8 @@ defmodule VintageNet.Technology.WiFiTest do
       ],
       up_cmd_millis: 60_000,
       up_cmds: [
+        {:run_ignore_errors, "/sbin/ifdown",
+         ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]},
         {:run_ignore_errors, "/usr/bin/killall", ["-q", "wpa_supplicant"]},
         {:run, "/usr/sbin/wpa_supplicant",
          ["-B", "-i", "wlan0", "-c", "/tmp/vintage_net/wpa_supplicant.conf.wlan0", "-dd"]},
@@ -781,6 +807,8 @@ defmodule VintageNet.Technology.WiFiTest do
       ],
       up_cmd_millis: 60_000,
       up_cmds: [
+        {:run_ignore_errors, "/sbin/ifdown",
+         ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]},
         {:run_ignore_errors, "/usr/bin/killall", ["-q", "wpa_supplicant"]},
         {:run, "/usr/sbin/wpa_supplicant",
          ["-B", "-i", "wlan0", "-c", "/tmp/vintage_net/wpa_supplicant.conf.wlan0", "-dd"]},
@@ -828,6 +856,8 @@ defmodule VintageNet.Technology.WiFiTest do
       ],
       up_cmd_millis: 60_000,
       up_cmds: [
+        {:run_ignore_errors, "/sbin/ifdown",
+         ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]},
         {:run_ignore_errors, "/usr/bin/killall", ["-q", "wpa_supplicant"]},
         {:run, "/usr/sbin/wpa_supplicant",
          ["-B", "-i", "wlan0", "-c", "/tmp/vintage_net/wpa_supplicant.conf.wlan0", "-dd"]},
@@ -875,6 +905,8 @@ defmodule VintageNet.Technology.WiFiTest do
       ],
       up_cmd_millis: 60_000,
       up_cmds: [
+        {:run_ignore_errors, "/sbin/ifdown",
+         ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]},
         {:run_ignore_errors, "/usr/bin/killall", ["-q", "wpa_supplicant"]},
         {:run, "/usr/sbin/wpa_supplicant",
          ["-B", "-i", "wlan0", "-c", "/tmp/vintage_net/wpa_supplicant.conf.wlan0", "-dd"]},
@@ -924,6 +956,8 @@ defmodule VintageNet.Technology.WiFiTest do
       ],
       up_cmd_millis: 60_000,
       up_cmds: [
+        {:run_ignore_errors, "/sbin/ifdown",
+         ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]},
         {:run_ignore_errors, "/usr/bin/killall", ["-q", "wpa_supplicant"]},
         {:run, "/usr/sbin/wpa_supplicant",
          ["-B", "-i", "wlan0", "-c", "/tmp/vintage_net/wpa_supplicant.conf.wlan0", "-dd"]},
@@ -1003,6 +1037,8 @@ defmodule VintageNet.Technology.WiFiTest do
       ],
       up_cmd_millis: 60_000,
       up_cmds: [
+        {:run_ignore_errors, "/sbin/ifdown",
+         ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]},
         {:run_ignore_errors, "/usr/bin/killall", ["-q", "wpa_supplicant"]},
         {:run, "/usr/sbin/wpa_supplicant",
          ["-B", "-i", "wlan0", "-c", "/tmp/vintage_net/wpa_supplicant.conf.wlan0", "-dd"]},
@@ -1074,6 +1110,8 @@ defmodule VintageNet.Technology.WiFiTest do
       ],
       up_cmd_millis: 60_000,
       up_cmds: [
+        {:run_ignore_errors, "/sbin/ifdown",
+         ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]},
         {:run_ignore_errors, "/usr/bin/killall", ["-q", "wpa_supplicant"]},
         {:run, "/usr/sbin/wpa_supplicant",
          ["-B", "-i", "wlan0", "-c", "/tmp/vintage_net/wpa_supplicant.conf.wlan0", "-dd"]},
@@ -1153,6 +1191,8 @@ defmodule VintageNet.Technology.WiFiTest do
       ],
       up_cmd_millis: 60_000,
       up_cmds: [
+        {:run_ignore_errors, "/sbin/ifdown",
+         ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]},
         {:run_ignore_errors, "/usr/bin/killall", ["-q", "wpa_supplicant"]},
         {:run, "/usr/sbin/wpa_supplicant",
          ["-B", "-i", "wlan0", "-c", "/tmp/vintage_net/wpa_supplicant.conf.wlan0", "-dd"]},

--- a/test/vintage_net/technology/wifi_test.exs
+++ b/test/vintage_net/technology/wifi_test.exs
@@ -5,6 +5,33 @@ defmodule VintageNet.Technology.WiFiTest do
 
   import VintageNetTest.Utils
 
+  defp normalize_config(config) do
+    {:ok, normalized} = WiFi.normalize(config)
+    normalized
+  end
+
+  test "normalization converts passphrases to psks" do
+    input = %{
+      type: VintageNet.Technology.WiFi,
+      wifi: %{
+        ssid: "IEEE",
+        psk: "password",
+        key_mgmt: :wpa_psk
+      }
+    }
+
+    normalized_input = %{
+      type: VintageNet.Technology.WiFi,
+      wifi: %{
+        ssid: "IEEE",
+        psk: "F42C6FC52DF0EBEF9EBB4B90B38A5F902E83FE1B135A70E23AED762E9710A12E",
+        key_mgmt: :wpa_psk
+      }
+    }
+
+    assert {:ok, normalized_input} == WiFi.normalize(input)
+  end
+
   test "create a WPA2 WiFi configuration" do
     input = %{
       type: VintageNet.Technology.WiFi,
@@ -20,7 +47,7 @@ defmodule VintageNet.Technology.WiFiTest do
     output = %RawConfig{
       ifname: "wlan0",
       type: VintageNet.Technology.WiFi,
-      source_config: input,
+      source_config: normalize_config(input),
       child_specs: [{VintageNet.Interface.ConnectivityChecker, "wlan0"}],
       files: [
         {"/tmp/vintage_net/network_interfaces.wlan0", dhcp_interface("wlan0", "unit_test")},
@@ -67,7 +94,7 @@ defmodule VintageNet.Technology.WiFiTest do
     output = %RawConfig{
       ifname: "wlan0",
       type: VintageNet.Technology.WiFi,
-      source_config: input,
+      source_config: normalize_config(input),
       child_specs: [{VintageNet.Interface.ConnectivityChecker, "wlan0"}],
       files: [
         {"/tmp/vintage_net/network_interfaces.wlan0", dhcp_interface("wlan0", "unit_test")},
@@ -113,7 +140,7 @@ defmodule VintageNet.Technology.WiFiTest do
     output = %RawConfig{
       ifname: "wlan0",
       type: VintageNet.Technology.WiFi,
-      source_config: input,
+      source_config: normalize_config(input),
       child_specs: [{VintageNet.Interface.ConnectivityChecker, "wlan0"}],
       files: [
         {"/tmp/vintage_net/network_interfaces.wlan0", dhcp_interface("wlan0", "unit_test")},
@@ -164,7 +191,7 @@ defmodule VintageNet.Technology.WiFiTest do
     output = %RawConfig{
       ifname: "wlan0",
       type: VintageNet.Technology.WiFi,
-      source_config: input,
+      source_config: normalize_config(input),
       child_specs: [{VintageNet.Interface.ConnectivityChecker, "wlan0"}],
       files: [
         {"/tmp/vintage_net/network_interfaces.wlan0", dhcp_interface("wlan0", "unit_test")},
@@ -217,7 +244,7 @@ defmodule VintageNet.Technology.WiFiTest do
     output = %RawConfig{
       ifname: "wlan0",
       type: VintageNet.Technology.WiFi,
-      source_config: input,
+      source_config: normalize_config(input),
       child_specs: [{VintageNet.Interface.ConnectivityChecker, "wlan0"}],
       files: [
         {"/tmp/vintage_net/network_interfaces.wlan0", dhcp_interface("wlan0", "unit_test")},
@@ -272,7 +299,7 @@ defmodule VintageNet.Technology.WiFiTest do
     output = %RawConfig{
       ifname: "wlan0",
       type: VintageNet.Technology.WiFi,
-      source_config: input,
+      source_config: normalize_config(input),
       child_specs: [{VintageNet.Interface.ConnectivityChecker, "wlan0"}],
       files: [
         {"/tmp/vintage_net/network_interfaces.wlan0", dhcp_interface("wlan0", "unit_test")},
@@ -330,7 +357,7 @@ defmodule VintageNet.Technology.WiFiTest do
     output = %RawConfig{
       ifname: "wlan0",
       type: VintageNet.Technology.WiFi,
-      source_config: input,
+      source_config: normalize_config(input),
       child_specs: [{VintageNet.Interface.ConnectivityChecker, "wlan0"}],
       files: [
         {"/tmp/vintage_net/network_interfaces.wlan0", dhcp_interface("wlan0", "unit_test")},
@@ -388,7 +415,7 @@ defmodule VintageNet.Technology.WiFiTest do
     output = %RawConfig{
       ifname: "wlan0",
       type: VintageNet.Technology.WiFi,
-      source_config: input,
+      source_config: normalize_config(input),
       child_specs: [{VintageNet.Interface.ConnectivityChecker, "wlan0"}],
       files: [
         {"/tmp/vintage_net/network_interfaces.wlan0", dhcp_interface("wlan0", "unit_test")},
@@ -448,7 +475,7 @@ defmodule VintageNet.Technology.WiFiTest do
     output = %RawConfig{
       ifname: "wlan0",
       type: VintageNet.Technology.WiFi,
-      source_config: input,
+      source_config: normalize_config(input),
       child_specs: [{VintageNet.Interface.ConnectivityChecker, "wlan0"}],
       files: [
         {"/tmp/vintage_net/network_interfaces.wlan0", dhcp_interface("wlan0", "unit_test")},
@@ -506,7 +533,7 @@ defmodule VintageNet.Technology.WiFiTest do
     output = %RawConfig{
       ifname: "wlan0",
       type: VintageNet.Technology.WiFi,
-      source_config: input,
+      source_config: normalize_config(input),
       child_specs: [{VintageNet.Interface.ConnectivityChecker, "wlan0"}],
       files: [
         {"/tmp/vintage_net/network_interfaces.wlan0", dhcp_interface("wlan0", "unit_test")},
@@ -566,7 +593,7 @@ defmodule VintageNet.Technology.WiFiTest do
     output = %RawConfig{
       ifname: "wlan0",
       type: VintageNet.Technology.WiFi,
-      source_config: input,
+      source_config: normalize_config(input),
       child_specs: [{VintageNet.Interface.ConnectivityChecker, "wlan0"}],
       files: [
         {"/tmp/vintage_net/network_interfaces.wlan0", dhcp_interface("wlan0", "unit_test")},
@@ -623,7 +650,7 @@ defmodule VintageNet.Technology.WiFiTest do
     output = %RawConfig{
       ifname: "wlan0",
       type: VintageNet.Technology.WiFi,
-      source_config: input,
+      source_config: normalize_config(input),
       child_specs: [{VintageNet.Interface.ConnectivityChecker, "wlan0"}],
       files: [
         {"/tmp/vintage_net/network_interfaces.wlan0", dhcp_interface("wlan0", "unit_test")},
@@ -675,7 +702,7 @@ defmodule VintageNet.Technology.WiFiTest do
     output = %RawConfig{
       ifname: "wlan0",
       type: VintageNet.Technology.WiFi,
-      source_config: input,
+      source_config: normalize_config(input),
       child_specs: [{VintageNet.Interface.ConnectivityChecker, "wlan0"}],
       files: [
         {"/tmp/vintage_net/network_interfaces.wlan0", dhcp_interface("wlan0", "unit_test")},
@@ -731,7 +758,7 @@ defmodule VintageNet.Technology.WiFiTest do
     output = %RawConfig{
       ifname: "wlan0",
       type: VintageNet.Technology.WiFi,
-      source_config: input,
+      source_config: normalize_config(input),
       child_specs: [{VintageNet.Interface.ConnectivityChecker, "wlan0"}],
       files: [
         {"/tmp/vintage_net/network_interfaces.wlan0", dhcp_interface("wlan0", "unit_test")},
@@ -784,7 +811,7 @@ defmodule VintageNet.Technology.WiFiTest do
     output = %RawConfig{
       ifname: "wlan0",
       type: VintageNet.Technology.WiFi,
-      source_config: input,
+      source_config: normalize_config(input),
       child_specs: [{VintageNet.Interface.ConnectivityChecker, "wlan0"}],
       files: [
         {"/tmp/vintage_net/network_interfaces.wlan0", dhcp_interface("wlan0", "unit_test")},
@@ -831,7 +858,7 @@ defmodule VintageNet.Technology.WiFiTest do
     output = %RawConfig{
       ifname: "wlan0",
       type: VintageNet.Technology.WiFi,
-      source_config: input,
+      source_config: normalize_config(input),
       child_specs: [{VintageNet.Interface.ConnectivityChecker, "wlan0"}],
       files: [
         {"/tmp/vintage_net/network_interfaces.wlan0", dhcp_interface("wlan0", "unit_test")},
@@ -879,7 +906,7 @@ defmodule VintageNet.Technology.WiFiTest do
     output = %RawConfig{
       ifname: "wlan0",
       type: VintageNet.Technology.WiFi,
-      source_config: input,
+      source_config: normalize_config(input),
       child_specs: [{VintageNet.Interface.ConnectivityChecker, "wlan0"}],
       files: [
         {"/tmp/vintage_net/network_interfaces.wlan0", dhcp_interface("wlan0", "unit_test")},
@@ -946,7 +973,7 @@ defmodule VintageNet.Technology.WiFiTest do
     output = %RawConfig{
       ifname: "wlan0",
       type: VintageNet.Technology.WiFi,
-      source_config: input,
+      source_config: normalize_config(input),
       child_specs: [{VintageNet.Interface.ConnectivityChecker, "wlan0"}],
       files: [
         {"/tmp/vintage_net/network_interfaces.wlan0", dhcp_interface("wlan0", "unit_test")},
@@ -1017,7 +1044,7 @@ defmodule VintageNet.Technology.WiFiTest do
     output = %RawConfig{
       ifname: "wlan0",
       type: VintageNet.Technology.WiFi,
-      source_config: input,
+      source_config: normalize_config(input),
       child_specs: [{VintageNet.Interface.ConnectivityChecker, "wlan0"}],
       files: [
         {"/tmp/vintage_net/network_interfaces.wlan0",
@@ -1089,7 +1116,7 @@ defmodule VintageNet.Technology.WiFiTest do
     output = %RawConfig{
       ifname: "wlan0",
       type: VintageNet.Technology.WiFi,
-      source_config: input,
+      source_config: normalize_config(input),
       child_specs: [{VintageNet.Interface.ConnectivityChecker, "wlan0"}],
       files: [
         {"/tmp/vintage_net/network_interfaces.wlan0",

--- a/test/vintage_net/technology/wifi_test.exs
+++ b/test/vintage_net/technology/wifi_test.exs
@@ -35,6 +35,7 @@ defmodule VintageNet.Technology.WiFiTest do
          }
          """}
       ],
+      up_cmd_millis: 60_000,
       up_cmds: [
         {:run_ignore_errors, "/usr/bin/killall", ["-q", "wpa_supplicant"]},
         {:run, "/usr/sbin/wpa_supplicant",
@@ -81,6 +82,7 @@ defmodule VintageNet.Technology.WiFiTest do
          }
          """}
       ],
+      up_cmd_millis: 60_000,
       up_cmds: [
         {:run_ignore_errors, "/usr/bin/killall", ["-q", "wpa_supplicant"]},
         {:run, "/usr/sbin/wpa_supplicant",
@@ -125,6 +127,7 @@ defmodule VintageNet.Technology.WiFiTest do
          }
          """}
       ],
+      up_cmd_millis: 60_000,
       up_cmds: [
         {:run_ignore_errors, "/usr/bin/killall", ["-q", "wpa_supplicant"]},
         {:run, "/usr/sbin/wpa_supplicant",
@@ -181,6 +184,7 @@ defmodule VintageNet.Technology.WiFiTest do
          }
          """}
       ],
+      up_cmd_millis: 60_000,
       up_cmds: [
         {:run_ignore_errors, "/usr/bin/killall", ["-q", "wpa_supplicant"]},
         {:run, "/usr/sbin/wpa_supplicant",
@@ -229,6 +233,7 @@ defmodule VintageNet.Technology.WiFiTest do
          }
          """}
       ],
+      up_cmd_millis: 60_000,
       up_cmds: [
         {:run_ignore_errors, "/usr/bin/killall", ["-q", "wpa_supplicant"]},
         {:run, "/usr/sbin/wpa_supplicant",
@@ -289,6 +294,7 @@ defmodule VintageNet.Technology.WiFiTest do
          }
          """}
       ],
+      up_cmd_millis: 60_000,
       up_cmds: [
         {:run_ignore_errors, "/usr/bin/killall", ["-q", "wpa_supplicant"]},
         {:run, "/usr/sbin/wpa_supplicant",
@@ -342,6 +348,7 @@ defmodule VintageNet.Technology.WiFiTest do
          }
          """}
       ],
+      up_cmd_millis: 60_000,
       up_cmds: [
         {:run_ignore_errors, "/usr/bin/killall", ["-q", "wpa_supplicant"]},
         {:run, "/usr/sbin/wpa_supplicant",
@@ -403,6 +410,7 @@ defmodule VintageNet.Technology.WiFiTest do
          }
          """}
       ],
+      up_cmd_millis: 60_000,
       up_cmds: [
         {:run_ignore_errors, "/usr/bin/killall", ["-q", "wpa_supplicant"]},
         {:run, "/usr/sbin/wpa_supplicant",
@@ -461,6 +469,7 @@ defmodule VintageNet.Technology.WiFiTest do
          }
          """}
       ],
+      up_cmd_millis: 60_000,
       up_cmds: [
         {:run_ignore_errors, "/usr/bin/killall", ["-q", "wpa_supplicant"]},
         {:run, "/usr/sbin/wpa_supplicant",
@@ -517,6 +526,7 @@ defmodule VintageNet.Technology.WiFiTest do
          }
          """}
       ],
+      up_cmd_millis: 60_000,
       up_cmds: [
         {:run_ignore_errors, "/usr/bin/killall", ["-q", "wpa_supplicant"]},
         {:run, "/usr/sbin/wpa_supplicant",
@@ -579,6 +589,7 @@ defmodule VintageNet.Technology.WiFiTest do
          }
          """}
       ],
+      up_cmd_millis: 60_000,
       up_cmds: [
         {:run_ignore_errors, "/usr/bin/killall", ["-q", "wpa_supplicant"]},
         {:run, "/usr/sbin/wpa_supplicant",
@@ -629,6 +640,7 @@ defmodule VintageNet.Technology.WiFiTest do
          }
          """}
       ],
+      up_cmd_millis: 60_000,
       up_cmds: [
         {:run_ignore_errors, "/usr/bin/killall", ["-q", "wpa_supplicant"]},
         {:run, "/usr/sbin/wpa_supplicant",
@@ -681,6 +693,7 @@ defmodule VintageNet.Technology.WiFiTest do
          }
          """}
       ],
+      up_cmd_millis: 60_000,
       up_cmds: [
         {:run_ignore_errors, "/usr/bin/killall", ["-q", "wpa_supplicant"]},
         {:run, "/usr/sbin/wpa_supplicant",
@@ -739,6 +752,7 @@ defmodule VintageNet.Technology.WiFiTest do
          }
          """}
       ],
+      up_cmd_millis: 60_000,
       up_cmds: [
         {:run_ignore_errors, "/usr/bin/killall", ["-q", "wpa_supplicant"]},
         {:run, "/usr/sbin/wpa_supplicant",
@@ -785,6 +799,7 @@ defmodule VintageNet.Technology.WiFiTest do
          }
          """}
       ],
+      up_cmd_millis: 60_000,
       up_cmds: [
         {:run_ignore_errors, "/usr/bin/killall", ["-q", "wpa_supplicant"]},
         {:run, "/usr/sbin/wpa_supplicant",
@@ -831,6 +846,7 @@ defmodule VintageNet.Technology.WiFiTest do
          }
          """}
       ],
+      up_cmd_millis: 60_000,
       up_cmds: [
         {:run_ignore_errors, "/usr/bin/killall", ["-q", "wpa_supplicant"]},
         {:run, "/usr/sbin/wpa_supplicant",
@@ -879,6 +895,7 @@ defmodule VintageNet.Technology.WiFiTest do
          }
          """}
       ],
+      up_cmd_millis: 60_000,
       up_cmds: [
         {:run_ignore_errors, "/usr/bin/killall", ["-q", "wpa_supplicant"]},
         {:run, "/usr/sbin/wpa_supplicant",
@@ -957,6 +974,7 @@ defmodule VintageNet.Technology.WiFiTest do
          }
          """}
       ],
+      up_cmd_millis: 60_000,
       up_cmds: [
         {:run_ignore_errors, "/usr/bin/killall", ["-q", "wpa_supplicant"]},
         {:run, "/usr/sbin/wpa_supplicant",
@@ -1027,6 +1045,7 @@ defmodule VintageNet.Technology.WiFiTest do
          }
          """}
       ],
+      up_cmd_millis: 60_000,
       up_cmds: [
         {:run_ignore_errors, "/usr/bin/killall", ["-q", "wpa_supplicant"]},
         {:run, "/usr/sbin/wpa_supplicant",
@@ -1105,6 +1124,7 @@ defmodule VintageNet.Technology.WiFiTest do
 
          """}
       ],
+      up_cmd_millis: 60_000,
       up_cmds: [
         {:run_ignore_errors, "/usr/bin/killall", ["-q", "wpa_supplicant"]},
         {:run, "/usr/sbin/wpa_supplicant",


### PR DESCRIPTION
It's easiest to review the commits individually since they're each pretty small. I'll definitely split if any prove controversial.

At a high level, this fixes a few blatant bugs and fixes a supervision issue where `RouteManager` and `Interface` crashes were not recoverable. The fundamental issues were 1) incorrect supervision strategy (now `:rest_for_one`) and 2) `ifdown` always needs to be tried to prevent `ifup` from exiting without doing anything.