### PR TITLE
More cleanup when changing configurations; code cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,8 +286,7 @@ iex> VintageNet.configure("wlan0", %{
       ipv4: %{
         method: :static,
         address: "192.168.24.1",
-        netmask: "255.255.255.0",
-        gateway: "192.168.24.1"
+        netmask: "255.255.255.0"
       },
       dhcpd: %{
         start: "192.168.24.2",

--- a/lib/vintage_net.ex
+++ b/lib/vintage_net.ex
@@ -190,8 +190,19 @@ defmodule VintageNet do
         print_if_attribute(ifname, "present", "Present")
         print_if_attribute(ifname, "state", "State")
         print_if_attribute(ifname, "connection", "Connection")
+        IO.puts("  Configuration:")
+        print_config(ifname, "    ")
       end)
     end
+  end
+
+  defp print_config(ifname, prefix) do
+    VintageNet.get_configuration(ifname)
+    |> inspect(pretty: true, width: 80 - String.length(prefix))
+    |> String.split("\n")
+    |> Enum.map(fn s -> prefix <> s end)
+    |> Enum.intersperse("\n")
+    |> IO.puts()
   end
 
   defp print_if_attribute(ifname, name, print_name) do

--- a/lib/vintage_net/interface.ex
+++ b/lib/vintage_net/interface.ex
@@ -417,6 +417,7 @@ defmodule VintageNet.Interface do
 
     if interface_available?(data) do
       rm(new_config.cleanup_files)
+      cleanup_interface(data.ifname)
       CommandRunner.create_files(new_config.files)
       new_data = run_commands(data, new_config.up_cmds)
 
@@ -451,6 +452,7 @@ defmodule VintageNet.Interface do
 
     if interface_available?(data) do
       rm(new_config.cleanup_files)
+      cleanup_interface(data.ifname)
       CommandRunner.create_files(new_config.files)
       new_data = run_commands(data, new_config.up_cmds)
 
@@ -484,6 +486,7 @@ defmodule VintageNet.Interface do
 
     if interface_available?(data) do
       rm(new_config.cleanup_files)
+      cleanup_interface(data.ifname)
       CommandRunner.create_files(new_config.files)
       new_data = run_commands(data, new_config.up_cmds)
 
@@ -518,6 +521,7 @@ defmodule VintageNet.Interface do
 
     if interface_available?(data) do
       rm(new_config.cleanup_files)
+      cleanup_interface(data.ifname)
       CommandRunner.create_files(new_config.files)
       new_data = run_commands(data, new_config.up_cmds)
 
@@ -542,6 +546,7 @@ defmodule VintageNet.Interface do
   def handle_event(:state_timeout, _event, :retrying, %State{config: new_config} = data) do
     if interface_available?(data) do
       rm(new_config.cleanup_files)
+      cleanup_interface(data.ifname)
       CommandRunner.create_files(new_config.files)
       new_data = run_commands(data, new_config.up_cmds)
 
@@ -564,6 +569,7 @@ defmodule VintageNet.Interface do
         %State{ifname: ifname, config: new_config} = data
       ) do
     rm(new_config.cleanup_files)
+    cleanup_interface(data.ifname)
     CommandRunner.create_files(new_config.files)
     new_data = run_commands(data, new_config.up_cmds)
 
@@ -589,6 +595,7 @@ defmodule VintageNet.Interface do
 
     if interface_available?(data) do
       rm(new_config.cleanup_files)
+      cleanup_interface(data.ifname)
       CommandRunner.create_files(new_config.files)
       new_data = run_commands(data, new_config.up_cmds)
 

--- a/lib/vintage_net/route/ip_route.ex
+++ b/lib/vintage_net/route/ip_route.ex
@@ -1,6 +1,6 @@
 defmodule VintageNet.Route.IPRoute do
   @moduledoc """
-  This module knows how to invoke `ip` to change the routing table
+  This module knows how to invoke the `ip` command to modify the Linux routing tables
   """
 
   require Logger
@@ -110,17 +110,26 @@ defmodule VintageNet.Route.IPRoute do
     end
   end
 
+  @doc """
+  Clear one default route out of the main table for any interface
+  """
   @spec clear_a_route() :: :ok | {:error, any()}
   def clear_a_route() do
     ip_cmd(["route", "del", "default"])
   end
 
+  @doc """
+  Clear one default route that goes to the specified interface
+  """
   @spec clear_a_route(VintageNet.ifname(), Calculator.table_index()) :: :ok | {:error, any()}
   def clear_a_route(ifname, table_index \\ :main) do
     table_index_string = table_index_to_string(table_index)
     ip_cmd(["route", "del", "default", "table", table_index_string, "dev", ifname])
   end
 
+  @doc """
+  Clear one local route
+  """
   @spec clear_a_local_route(
           VintageNet.ifname(),
           :inet.ip_address(),
@@ -149,11 +158,17 @@ defmodule VintageNet.Route.IPRoute do
     ])
   end
 
+  @doc """
+  Clear one local route generically
+  """
   @spec clear_a_local_route(VintageNet.ifname()) :: :ok | {:error, any()}
   def clear_a_local_route(ifname) do
     ip_cmd(["route", "del", "dev", ifname, "scope", "link"])
   end
 
+  @doc """
+  Clear out one rule
+  """
   @spec clear_a_rule(Calculator.table_index()) :: :ok | {:error, any()}
   def clear_a_rule(table_index) do
     table_index_string = table_index_to_string(table_index)


### PR DESCRIPTION
This cleans up the routing tables when changing configurations. There's some sloppiness due to our current use of `ifupdown` that results in `RouteManager` crashes. Everything recovers, so that's good, but it's kind of ugly. This cleans the slate better and avoids the crashes.

Specifically, it fixes `RouteManager` crashes when transitioning between AP mode and client mode on wireless LANs.

I put in a variety of other code cleanup while I was debugging.