### PR TITLE
Fix ap mode control_interface_path

### DIFF
--- a/lib/vintage_net/technology/wifi.ex
+++ b/lib/vintage_net/technology/wifi.ex
@@ -26,7 +26,7 @@ defmodule VintageNet.Technology.WiFi do
     network_interfaces_path = Path.join(tmpdir, "network_interfaces.#{ifname}")
     wpa_supplicant_conf_path = Path.join(tmpdir, "wpa_supplicant.conf.#{ifname}")
     control_interface_dir = Path.join(tmpdir, "wpa_supplicant")
-    control_interface_path = Path.join(control_interface_dir, ifname)
+    control_interface_path = ctrl_interface_path(ifname, control_interface_dir, config)
 
     {:ok, normalized_config} = normalize(config)
 
@@ -90,14 +90,14 @@ defmodule VintageNet.Technology.WiFi do
     end
   end
 
-  def to_raw_config(ifname, %{type: __MODULE__}, opts) do
+  def to_raw_config(ifname, %{type: __MODULE__} = config, opts) do
     wpa_supplicant = Keyword.fetch!(opts, :bin_wpa_supplicant)
     killall = Keyword.fetch!(opts, :bin_killall)
     tmpdir = Keyword.fetch!(opts, :tmpdir)
 
     wpa_supplicant_conf_path = Path.join(tmpdir, "wpa_supplicant.conf.#{ifname}")
     control_interface_dir = Path.join(tmpdir, "wpa_supplicant")
-    control_interface_path = Path.join(control_interface_dir, ifname)
+    control_interface_path = ctrl_interface_path(ifname, control_interface_dir, config)
 
     files = [
       {wpa_supplicant_conf_path, "ctrl_interface=#{control_interface_dir}"}
@@ -437,4 +437,10 @@ defmodule VintageNet.Technology.WiFi do
       conf -> [conf, "\n"]
     end)
   end
+
+  defp ctrl_interface_path(ifname, dir, %{wifi: %{mode: mode}}) when mode in [:host, 2],
+    do: Path.join(dir, "p2p-dev-#{ifname}")
+
+  defp ctrl_interface_path(ifname, dir, _),
+    do: Path.join(dir, ifname)
 end

--- a/test/vintage_net/technology/wifi_test.exs
+++ b/test/vintage_net/technology/wifi_test.exs
@@ -1006,7 +1006,7 @@ defmodule VintageNet.Technology.WiFiTest do
       child_specs: [
         {VintageNet.Interface.ConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
-         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant/wlan0"]}
+         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant/p2p-dev-wlan0"]}
       ],
       files: [
         {"/tmp/vintage_net/network_interfaces.wlan0", dhcp_interface("wlan0", "unit_test")},
@@ -1035,7 +1035,7 @@ defmodule VintageNet.Technology.WiFiTest do
         {:run, "ifdown", ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]},
         {:run, "killall", ["-q", "wpa_supplicant"]}
       ],
-      cleanup_files: ["/tmp/vintage_net/wpa_supplicant/wlan0"]
+      cleanup_files: ["/tmp/vintage_net/wpa_supplicant/p2p-dev-wlan0"]
     }
 
     assert {:ok, output} == WiFi.to_raw_config("wlan0", input, default_opts())
@@ -1234,7 +1234,7 @@ defmodule VintageNet.Technology.WiFiTest do
       child_specs: [
         {VintageNet.Interface.ConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
-         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant/wlan0"]}
+         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant/p2p-dev-wlan0"]}
       ],
       files: [
         {"/tmp/vintage_net/network_interfaces.wlan0",
@@ -1284,7 +1284,7 @@ defmodule VintageNet.Technology.WiFiTest do
         {:run, "killall", ["-q", "wpa_supplicant"]},
         {:run, "killall", ["-q", "udhcpd"]}
       ],
-      cleanup_files: ["/tmp/vintage_net/wpa_supplicant/wlan0"]
+      cleanup_files: ["/tmp/vintage_net/wpa_supplicant/p2p-dev-wlan0"]
     }
 
     assert {:ok, output} == WiFi.to_raw_config("wlan0", input, default_opts())


### PR DESCRIPTION
For some reason when booting in host mode, wpa_supplicant
creates a control path different than in client mode. This adds
the fix initially added in #39