### PR TITLE
Interface.ex simplification and handling of configure while configuring

### DIFF
--- a/lib/vintage_net/interface.ex
+++ b/lib/vintage_net/interface.ex
@@ -276,7 +276,7 @@ defmodule VintageNet.Interface do
   def handle_event(
         :info,
         {VintageNet, ["interface", ifname, "present"], _old_value, nil, _meta},
-        :reconfiguring,
+        :configuring,
         %State{ifname: ifname, command_runner: pid, config: config} = data
       ) do
     _ =


### PR DESCRIPTION
There's still a long way to go to simplify `interface.ex`, but it's slightly closer and I took a pass at implementing support for calling `configure` while `configuring`. It cancels the in-progress configuration, does some cleanup and then starts the next one. 