### PR TITLE
 Handle WiFi drivers w/o separate P2P interfaces

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ install_system_deps: &install_system_deps
     name: Install system dependencies
     command: |
       apt update
-      apt install -y unzip libmnl-dev
+      apt install -y unzip libmnl-dev libnl-genl-3-dev
 
 install_mdl: &install_mdl
   run:

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,9 @@
 # ERL_EI_LIBDIR path to libei.a (Required for crosscompile)
 # LDFLAGS	linker flags for linking all binaries
 # ERL_LDFLAGS	additional linker flags for projects referencing Erlang libraries
-
+# PKG_CONFIG_SYSROOT_DIR sysroot for pkg-config (for finding libnl-3)
+# PKG_CONFIG_PATH pkg-config metadata
+#
 ifeq ($(MIX_COMPILE_PATH),)
 call_from_make:
 	mix compile
@@ -26,10 +28,18 @@ endif
 PREFIX = $(MIX_COMPILE_PATH)/../priv
 BUILD  = $(MIX_COMPILE_PATH)/../obj
 
+# Set Erlang-specific compile and linker flags
+ERL_CFLAGS ?= -I$(ERL_EI_INCLUDE_DIR)
+ERL_LDFLAGS = -L$(ERL_EI_LIBDIR) -lei_st
+
+CFLAGS ?= -O2 -Wall -Wextra -Wno-unused-parameter -pedantic
+
 # Check that we're on a supported build platform
 ifeq ($(CROSSCOMPILE),)
     # Not crosscompiling, so check that we're on Linux.
-    ifneq ($(shell uname -s),Linux)
+    ifeq ($(shell uname -s),Linux)
+        CFLAGS += $(shell pkg-config --cflags libnl-genl-3.0)
+    else
         $(warning vintage_net only works on Linux, but crosscompilation)
         $(warning is supported by defining $$CROSSCOMPILE, $$ERL_EI_INCLUDE_DIR,)
         $(warning and $$ERL_EI_LIBDIR. See Makefile for details. If using Nerves,)
@@ -38,15 +48,22 @@ ifeq ($(CROSSCOMPILE),)
         $(warning Skipping some C compilation unless targets explicitly passed to make.)
         DEFAULT_TARGETS ?= $(PREFIX) $(PREFIX)/to_elixir $(PREFIX)/udhcpc_handler $(PREFIX)/udhcpd_handler
     endif
+else
+    # Crosscompiling
+    ifeq ($(PKG_CONFIG_SYSROOT_DIR),)
+        # If pkg-config sysroot isn't set, then assume Nerves
+        CFLAGS += -I$(NERVES_SDK_SYSROOT)/usr/include/libnl3
+    else
+        # Use pkg-config to find libnl
+        CFLAGS += $(shell pkg-config --cflags libnl-genl-3.0)
+    endif
 endif
-DEFAULT_TARGETS ?= $(PREFIX) $(PREFIX)/to_elixir $(PREFIX)/udhcpc_handler $(PREFIX)/udhcpd_handler $(PREFIX)/if_monitor
-
-# Set Erlang-specific compile and linker flags
-ERL_CFLAGS ?= -I$(ERL_EI_INCLUDE_DIR)
-ERL_LDFLAGS = -L$(ERL_EI_LIBDIR) -lei_st
-
-CFLAGS ?= -O2 -Wall -Wextra -Wno-unused-parameter -pedantic
-CC ?= $(CROSSCOMPILE)-gcc
+DEFAULT_TARGETS ?= $(PREFIX) \
+		   $(PREFIX)/to_elixir \
+		   $(PREFIX)/udhcpc_handler \
+		   $(PREFIX)/udhcpd_handler \
+		   $(PREFIX)/if_monitor \
+		   $(PREFIX)/force_ap_scan
 
 # Enable for debug messages
 # CFLAGS += -DDEBUG
@@ -78,11 +95,19 @@ $(PREFIX)/udhcpd_handler $(PREFIX)/udhcpc_handler: $(PREFIX)/to_elixir
 $(PREFIX)/if_monitor: $(BUILD)/if_monitor.o
 	$(CC) $^ $(ERL_LDFLAGS) $(LDFLAGS) -lmnl -o $@
 
+$(PREFIX)/force_ap_scan: $(BUILD)/force_ap_scan.o
+	$(CC) $^ $(LDFLAGS) -lnl-3 -lnl-genl-3 -o $@
+
 $(PREFIX) $(BUILD):
 	mkdir -p $@
 
 clean:
-	$(RM) $(PREFIX)/to_elixir $(PREFIX)/udhcpc_handler $(PREFIX)/udhcpd_handler $(PREFIX)/if_monitor $(BUILD)/*.o
+	$(RM) $(PREFIX)/to_elixir \
+	    $(PREFIX)/udhcpc_handler \
+	    $(PREFIX)/udhcpd_handler \
+	    $(PREFIX)/if_monitor \
+	    $(PREFIX)/force_ap_scan \
+	    $(BUILD)/*.o
 
 format:
 	astyle \

--- a/src/force_ap_scan.c
+++ b/src/force_ap_scan.c
@@ -1,0 +1,71 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <err.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include <net/if.h>
+#include <netlink/genl/genl.h>
+#include <netlink/genl/ctrl.h>
+
+#include <linux/nl80211.h>
+
+/**
+ * Initiate a WiFi access point scan even when an adapter is in AP mode
+ *
+ * wpa_supplicant doesn't support setting the flag that makes this possible,
+ * so this is a short utility to do it.
+ */
+int main(int argc, char **argv)
+{
+    if (argc != 2)
+        errx(EXIT_FAILURE, "Specify a WiFi network device");
+
+    uint32_t ifindex = if_nametoindex(argv[1]);
+    if (ifindex == 0)
+        errx(EXIT_FAILURE, "Specify a WiFi device that works: %s", argv[1]);
+
+    struct nl_sock *nl_sock = nl_socket_alloc();
+    if (!nl_sock)
+        err(EXIT_FAILURE, "nl_socket_alloc");
+
+    if (genl_connect(nl_sock))
+        err(EXIT_FAILURE, "genl_connect");
+
+    int nl80211_id = genl_ctrl_resolve(nl_sock, "nl80211");
+    if (nl80211_id < 0)
+        err(EXIT_FAILURE, "genl_ctrl_resolve(nl80211)");
+
+    struct nl_msg *msg = nlmsg_alloc();
+    if (!msg)
+        err(EXIT_FAILURE, "nlmsg_alloc");
+
+    // msg, port, seq, family, hdrlen, flags, cmd, version
+    genlmsg_put(msg, 0, 0, nl80211_id, 0, 0, NL80211_CMD_TRIGGER_SCAN, 0);
+
+    uint32_t data;
+    data = ifindex;
+    nla_put(msg, NL80211_ATTR_IFINDEX, sizeof(data), &data);
+
+    data = NL80211_SCAN_FLAG_AP;
+    nla_put(msg, NL80211_ATTR_SCAN_FLAGS, sizeof(data), &data);
+
+    if (nl_send_auto(nl_sock, msg) < 0)
+        err(EXIT_FAILURE, "nl_send_auto");
+
+    nlmsg_free(msg);
+    nl_socket_free(nl_sock);
+    return 0;
+}

--- a/test/vintage_net/technology/wifi_test.exs
+++ b/test/vintage_net/technology/wifi_test.exs
@@ -51,7 +51,7 @@ defmodule VintageNet.Technology.WiFiTest do
       child_specs: [
         {VintageNet.Interface.ConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
-         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant/wlan0"]}
+         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant/wlan0", ap_mode: false]}
       ],
       files: [
         {"/tmp/vintage_net/network_interfaces.wlan0", dhcp_interface("wlan0", "unit_test")},
@@ -104,7 +104,7 @@ defmodule VintageNet.Technology.WiFiTest do
       child_specs: [
         {VintageNet.Interface.ConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
-         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant/wlan0"]}
+         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant/wlan0", ap_mode: false]}
       ],
       files: [
         {"/tmp/vintage_net/network_interfaces.wlan0", dhcp_interface("wlan0", "unit_test")},
@@ -156,7 +156,7 @@ defmodule VintageNet.Technology.WiFiTest do
       child_specs: [
         {VintageNet.Interface.ConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
-         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant/wlan0"]}
+         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant/wlan0", ap_mode: false]}
       ],
       files: [
         {"/tmp/vintage_net/network_interfaces.wlan0", dhcp_interface("wlan0", "unit_test")},
@@ -213,7 +213,7 @@ defmodule VintageNet.Technology.WiFiTest do
       child_specs: [
         {VintageNet.Interface.ConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
-         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant/wlan0"]}
+         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant/wlan0", ap_mode: false]}
       ],
       files: [
         {"/tmp/vintage_net/network_interfaces.wlan0", dhcp_interface("wlan0", "unit_test")},
@@ -272,7 +272,7 @@ defmodule VintageNet.Technology.WiFiTest do
       child_specs: [
         {VintageNet.Interface.ConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
-         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant/wlan0"]}
+         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant/wlan0", ap_mode: false]}
       ],
       files: [
         {"/tmp/vintage_net/network_interfaces.wlan0", dhcp_interface("wlan0", "unit_test")},
@@ -333,7 +333,7 @@ defmodule VintageNet.Technology.WiFiTest do
       child_specs: [
         {VintageNet.Interface.ConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
-         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant/wlan0"]}
+         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant/wlan0", ap_mode: false]}
       ],
       files: [
         {"/tmp/vintage_net/network_interfaces.wlan0", dhcp_interface("wlan0", "unit_test")},
@@ -397,7 +397,7 @@ defmodule VintageNet.Technology.WiFiTest do
       child_specs: [
         {VintageNet.Interface.ConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
-         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant/wlan0"]}
+         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant/wlan0", ap_mode: false]}
       ],
       files: [
         {"/tmp/vintage_net/network_interfaces.wlan0", dhcp_interface("wlan0", "unit_test")},
@@ -461,7 +461,7 @@ defmodule VintageNet.Technology.WiFiTest do
       child_specs: [
         {VintageNet.Interface.ConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
-         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant/wlan0"]}
+         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant/wlan0", ap_mode: false]}
       ],
       files: [
         {"/tmp/vintage_net/network_interfaces.wlan0", dhcp_interface("wlan0", "unit_test")},
@@ -527,7 +527,7 @@ defmodule VintageNet.Technology.WiFiTest do
       child_specs: [
         {VintageNet.Interface.ConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
-         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant/wlan0"]}
+         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant/wlan0", ap_mode: false]}
       ],
       files: [
         {"/tmp/vintage_net/network_interfaces.wlan0", dhcp_interface("wlan0", "unit_test")},
@@ -591,7 +591,7 @@ defmodule VintageNet.Technology.WiFiTest do
       child_specs: [
         {VintageNet.Interface.ConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
-         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant/wlan0"]}
+         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant/wlan0", ap_mode: false]}
       ],
       files: [
         {"/tmp/vintage_net/network_interfaces.wlan0", dhcp_interface("wlan0", "unit_test")},
@@ -657,7 +657,7 @@ defmodule VintageNet.Technology.WiFiTest do
       child_specs: [
         {VintageNet.Interface.ConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
-         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant/wlan0"]}
+         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant/wlan0", ap_mode: false]}
       ],
       files: [
         {"/tmp/vintage_net/network_interfaces.wlan0", dhcp_interface("wlan0", "unit_test")},
@@ -720,7 +720,7 @@ defmodule VintageNet.Technology.WiFiTest do
       child_specs: [
         {VintageNet.Interface.ConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
-         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant/wlan0"]}
+         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant/wlan0", ap_mode: false]}
       ],
       files: [
         {"/tmp/vintage_net/network_interfaces.wlan0", dhcp_interface("wlan0", "unit_test")},
@@ -778,7 +778,7 @@ defmodule VintageNet.Technology.WiFiTest do
       child_specs: [
         {VintageNet.Interface.ConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
-         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant/wlan0"]}
+         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant/wlan0", ap_mode: false]}
       ],
       files: [
         {"/tmp/vintage_net/network_interfaces.wlan0", dhcp_interface("wlan0", "unit_test")},
@@ -840,7 +840,7 @@ defmodule VintageNet.Technology.WiFiTest do
       child_specs: [
         {VintageNet.Interface.ConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
-         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant/wlan0"]}
+         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant/wlan0", ap_mode: false]}
       ],
       files: [
         {"/tmp/vintage_net/network_interfaces.wlan0", dhcp_interface("wlan0", "unit_test")},
@@ -899,7 +899,7 @@ defmodule VintageNet.Technology.WiFiTest do
       child_specs: [
         {VintageNet.Interface.ConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
-         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant/wlan0"]}
+         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant/wlan0", ap_mode: false]}
       ],
       files: [
         {"/tmp/vintage_net/network_interfaces.wlan0", dhcp_interface("wlan0", "unit_test")},
@@ -952,7 +952,7 @@ defmodule VintageNet.Technology.WiFiTest do
       child_specs: [
         {VintageNet.Interface.ConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
-         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant/wlan0"]}
+         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant/wlan0", ap_mode: false]}
       ],
       files: [
         {"/tmp/vintage_net/network_interfaces.wlan0", dhcp_interface("wlan0", "unit_test")},
@@ -1006,7 +1006,11 @@ defmodule VintageNet.Technology.WiFiTest do
       child_specs: [
         {VintageNet.Interface.ConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
-         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant/p2p-dev-wlan0"]}
+         [
+           ifname: "wlan0",
+           control_path: "/tmp/vintage_net/wpa_supplicant/p2p-dev-wlan0",
+           ap_mode: true
+         ]}
       ],
       files: [
         {"/tmp/vintage_net/network_interfaces.wlan0", dhcp_interface("wlan0", "unit_test")},
@@ -1079,7 +1083,7 @@ defmodule VintageNet.Technology.WiFiTest do
       child_specs: [
         {VintageNet.Interface.ConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
-         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant/wlan0"]}
+         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant/wlan0", ap_mode: false]}
       ],
       files: [
         {"/tmp/vintage_net/network_interfaces.wlan0", dhcp_interface("wlan0", "unit_test")},
@@ -1156,7 +1160,7 @@ defmodule VintageNet.Technology.WiFiTest do
       child_specs: [
         {VintageNet.Interface.ConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
-         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant/wlan0"]}
+         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant/wlan0", ap_mode: false]}
       ],
       files: [
         {"/tmp/vintage_net/network_interfaces.wlan0",
@@ -1234,7 +1238,11 @@ defmodule VintageNet.Technology.WiFiTest do
       child_specs: [
         {VintageNet.Interface.ConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
-         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant/p2p-dev-wlan0"]}
+         [
+           ifname: "wlan0",
+           control_path: "/tmp/vintage_net/wpa_supplicant/p2p-dev-wlan0",
+           ap_mode: true
+         ]}
       ],
       files: [
         {"/tmp/vintage_net/network_interfaces.wlan0",

--- a/test/vintage_net/technology/wifi_test.exs
+++ b/test/vintage_net/technology/wifi_test.exs
@@ -51,7 +51,7 @@ defmodule VintageNet.Technology.WiFiTest do
       child_specs: [
         {VintageNet.Interface.ConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
-         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant/wlan0", ap_mode: false]}
+         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant", ap_mode: false]}
       ],
       files: [
         {"/tmp/vintage_net/network_interfaces.wlan0", dhcp_interface("wlan0", "unit_test")},
@@ -104,7 +104,7 @@ defmodule VintageNet.Technology.WiFiTest do
       child_specs: [
         {VintageNet.Interface.ConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
-         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant/wlan0", ap_mode: false]}
+         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant", ap_mode: false]}
       ],
       files: [
         {"/tmp/vintage_net/network_interfaces.wlan0", dhcp_interface("wlan0", "unit_test")},
@@ -156,7 +156,7 @@ defmodule VintageNet.Technology.WiFiTest do
       child_specs: [
         {VintageNet.Interface.ConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
-         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant/wlan0", ap_mode: false]}
+         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant", ap_mode: false]}
       ],
       files: [
         {"/tmp/vintage_net/network_interfaces.wlan0", dhcp_interface("wlan0", "unit_test")},
@@ -213,7 +213,7 @@ defmodule VintageNet.Technology.WiFiTest do
       child_specs: [
         {VintageNet.Interface.ConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
-         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant/wlan0", ap_mode: false]}
+         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant", ap_mode: false]}
       ],
       files: [
         {"/tmp/vintage_net/network_interfaces.wlan0", dhcp_interface("wlan0", "unit_test")},
@@ -272,7 +272,7 @@ defmodule VintageNet.Technology.WiFiTest do
       child_specs: [
         {VintageNet.Interface.ConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
-         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant/wlan0", ap_mode: false]}
+         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant", ap_mode: false]}
       ],
       files: [
         {"/tmp/vintage_net/network_interfaces.wlan0", dhcp_interface("wlan0", "unit_test")},
@@ -333,7 +333,7 @@ defmodule VintageNet.Technology.WiFiTest do
       child_specs: [
         {VintageNet.Interface.ConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
-         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant/wlan0", ap_mode: false]}
+         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant", ap_mode: false]}
       ],
       files: [
         {"/tmp/vintage_net/network_interfaces.wlan0", dhcp_interface("wlan0", "unit_test")},
@@ -397,7 +397,7 @@ defmodule VintageNet.Technology.WiFiTest do
       child_specs: [
         {VintageNet.Interface.ConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
-         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant/wlan0", ap_mode: false]}
+         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant", ap_mode: false]}
       ],
       files: [
         {"/tmp/vintage_net/network_interfaces.wlan0", dhcp_interface("wlan0", "unit_test")},
@@ -461,7 +461,7 @@ defmodule VintageNet.Technology.WiFiTest do
       child_specs: [
         {VintageNet.Interface.ConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
-         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant/wlan0", ap_mode: false]}
+         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant", ap_mode: false]}
       ],
       files: [
         {"/tmp/vintage_net/network_interfaces.wlan0", dhcp_interface("wlan0", "unit_test")},
@@ -527,7 +527,7 @@ defmodule VintageNet.Technology.WiFiTest do
       child_specs: [
         {VintageNet.Interface.ConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
-         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant/wlan0", ap_mode: false]}
+         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant", ap_mode: false]}
       ],
       files: [
         {"/tmp/vintage_net/network_interfaces.wlan0", dhcp_interface("wlan0", "unit_test")},
@@ -591,7 +591,7 @@ defmodule VintageNet.Technology.WiFiTest do
       child_specs: [
         {VintageNet.Interface.ConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
-         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant/wlan0", ap_mode: false]}
+         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant", ap_mode: false]}
       ],
       files: [
         {"/tmp/vintage_net/network_interfaces.wlan0", dhcp_interface("wlan0", "unit_test")},
@@ -657,7 +657,7 @@ defmodule VintageNet.Technology.WiFiTest do
       child_specs: [
         {VintageNet.Interface.ConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
-         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant/wlan0", ap_mode: false]}
+         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant", ap_mode: false]}
       ],
       files: [
         {"/tmp/vintage_net/network_interfaces.wlan0", dhcp_interface("wlan0", "unit_test")},
@@ -720,7 +720,7 @@ defmodule VintageNet.Technology.WiFiTest do
       child_specs: [
         {VintageNet.Interface.ConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
-         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant/wlan0", ap_mode: false]}
+         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant", ap_mode: false]}
       ],
       files: [
         {"/tmp/vintage_net/network_interfaces.wlan0", dhcp_interface("wlan0", "unit_test")},
@@ -778,7 +778,7 @@ defmodule VintageNet.Technology.WiFiTest do
       child_specs: [
         {VintageNet.Interface.ConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
-         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant/wlan0", ap_mode: false]}
+         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant", ap_mode: false]}
       ],
       files: [
         {"/tmp/vintage_net/network_interfaces.wlan0", dhcp_interface("wlan0", "unit_test")},
@@ -840,7 +840,7 @@ defmodule VintageNet.Technology.WiFiTest do
       child_specs: [
         {VintageNet.Interface.ConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
-         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant/wlan0", ap_mode: false]}
+         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant", ap_mode: false]}
       ],
       files: [
         {"/tmp/vintage_net/network_interfaces.wlan0", dhcp_interface("wlan0", "unit_test")},
@@ -899,7 +899,7 @@ defmodule VintageNet.Technology.WiFiTest do
       child_specs: [
         {VintageNet.Interface.ConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
-         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant/wlan0", ap_mode: false]}
+         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant", ap_mode: false]}
       ],
       files: [
         {"/tmp/vintage_net/network_interfaces.wlan0", dhcp_interface("wlan0", "unit_test")},
@@ -952,7 +952,7 @@ defmodule VintageNet.Technology.WiFiTest do
       child_specs: [
         {VintageNet.Interface.ConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
-         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant/wlan0", ap_mode: false]}
+         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant", ap_mode: false]}
       ],
       files: [
         {"/tmp/vintage_net/network_interfaces.wlan0", dhcp_interface("wlan0", "unit_test")},
@@ -1006,11 +1006,7 @@ defmodule VintageNet.Technology.WiFiTest do
       child_specs: [
         {VintageNet.Interface.ConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
-         [
-           ifname: "wlan0",
-           control_path: "/tmp/vintage_net/wpa_supplicant/p2p-dev-wlan0",
-           ap_mode: true
-         ]}
+         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant", ap_mode: true]}
       ],
       files: [
         {"/tmp/vintage_net/network_interfaces.wlan0", dhcp_interface("wlan0", "unit_test")},
@@ -1039,7 +1035,10 @@ defmodule VintageNet.Technology.WiFiTest do
         {:run, "ifdown", ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]},
         {:run, "killall", ["-q", "wpa_supplicant"]}
       ],
-      cleanup_files: ["/tmp/vintage_net/wpa_supplicant/p2p-dev-wlan0"]
+      cleanup_files: [
+        "/tmp/vintage_net/wpa_supplicant/p2p-dev-wlan0",
+        "/tmp/vintage_net/wpa_supplicant/wlan0"
+      ]
     }
 
     assert {:ok, output} == WiFi.to_raw_config("wlan0", input, default_opts())
@@ -1083,7 +1082,7 @@ defmodule VintageNet.Technology.WiFiTest do
       child_specs: [
         {VintageNet.Interface.ConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
-         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant/wlan0", ap_mode: false]}
+         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant", ap_mode: false]}
       ],
       files: [
         {"/tmp/vintage_net/network_interfaces.wlan0", dhcp_interface("wlan0", "unit_test")},
@@ -1160,7 +1159,7 @@ defmodule VintageNet.Technology.WiFiTest do
       child_specs: [
         {VintageNet.Interface.ConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
-         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant/wlan0", ap_mode: false]}
+         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant", ap_mode: false]}
       ],
       files: [
         {"/tmp/vintage_net/network_interfaces.wlan0",
@@ -1238,11 +1237,7 @@ defmodule VintageNet.Technology.WiFiTest do
       child_specs: [
         {VintageNet.Interface.ConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
-         [
-           ifname: "wlan0",
-           control_path: "/tmp/vintage_net/wpa_supplicant/p2p-dev-wlan0",
-           ap_mode: true
-         ]}
+         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant", ap_mode: true]}
       ],
       files: [
         {"/tmp/vintage_net/network_interfaces.wlan0",
@@ -1293,7 +1288,10 @@ defmodule VintageNet.Technology.WiFiTest do
         {:run, "killall", ["-q", "wpa_supplicant"]},
         {:run, "killall", ["-q", "udhcpd"]}
       ],
-      cleanup_files: ["/tmp/vintage_net/wpa_supplicant/p2p-dev-wlan0"]
+      cleanup_files: [
+        "/tmp/vintage_net/wpa_supplicant/p2p-dev-wlan0",
+        "/tmp/vintage_net/wpa_supplicant/wlan0"
+      ]
     }
 
     assert {:ok, output} == WiFi.to_raw_config("wlan0", input, default_opts())


### PR DESCRIPTION
[Merge after #84]

Not all WiFi drivers expose a separate P2P control interface. This
refactors the control file logic so that it tries both the normal
control interface and the P2P interface when the driver is in AP mode.

This fixes an issue with a USB WiFi module that doesn't have this
interface. The Raspberry Pi, for example, has both the P2P and normal
control interface, but only the P2P interface is used when in AP mode.