### PR TITLE
Fix earmark deprecation warning

### DIFF
--- a/lib/vintage_net/wifi/utils.ex
+++ b/lib/vintage_net/wifi/utils.ex
@@ -16,7 +16,8 @@ defmodule VintageNet.WiFi.Utils do
   like to show a number of bars or some kind of signal
   strength.
 
-  See https://web.archive.org/web/20141222024740/http://www.ces.clemson.edu/linux/nm-ipw2200.shtml
+  See [Displaying Associated and Scanned Signal
+  Levels](https://web.archive.org/web/20141222024740/http://www.ces.clemson.edu/linux/nm-ipw2200.shtml).
   """
   @spec dbm_to_percent(number(), number(), number()) :: 1..100
   def dbm_to_percent(dbm, best_dbm, _worst_dbm) when dbm >= best_dbm do


### PR DESCRIPTION
Fixes this message:

```
lib/vintage_net/wifi/utils.ex:19: deprecation: The string "https://github.com/pragdave/earmark" will be rendered as a link if the option `pure_links` is enabled.
This will be the case by default in version 1.4.
Disable the option explicitly with `false` to avoid this message.
```