### PR TITLE
Remove gratuitous clear_route messages; remove hardcoded restart_strategy

### DIFF
--- a/lib/vintage_net/interface.ex
+++ b/lib/vintage_net/interface.ex
@@ -193,7 +193,11 @@ defmodule VintageNet.Interface do
 
     update_properties(:configured, new_data)
 
-    VintageNet.Interface.Supervisor.set_technology(data.ifname, data.config.child_specs)
+    VintageNet.Interface.Supervisor.set_technology(
+      data.ifname,
+      data.config.restart_strategy,
+      data.config.child_specs
+    )
 
     {:next_state, :configured, new_data, actions}
   end

--- a/lib/vintage_net/interface/raw_config.ex
+++ b/lib/vintage_net/interface/raw_config.ex
@@ -13,6 +13,7 @@ defmodule VintageNet.Interface.RawConfig do
   * `require_interface` - require the interface to exist in the system before configuring
   * `retry_millis` - if bringing the interface up fails, wait this amount of time before retrying
   * `files` - a list of file path, content tuples
+  * `child_specs` - a set of child_specs for GenServers to start up and supervise
   * `up_cmd_millis` - the maximum amount of time to allow the up command list to take
   * `up_cmds` - a list of commands to run to configure the interface
   * `down_cmd_millis` - the maximum amount of time to allow the down command list to take

--- a/lib/vintage_net/interface/raw_config.ex
+++ b/lib/vintage_net/interface/raw_config.ex
@@ -13,6 +13,7 @@ defmodule VintageNet.Interface.RawConfig do
   * `require_interface` - require the interface to exist in the system before configuring
   * `retry_millis` - if bringing the interface up fails, wait this amount of time before retrying
   * `files` - a list of file path, content tuples
+  * `restart_strategy` - the restart strategy for the list of `child_specs`. I.e., `:one_for_one | :one_for_all | :rest_for_one
   * `child_specs` - a set of child_specs for GenServers to start up and supervise
   * `up_cmd_millis` - the maximum amount of time to allow the up command list to take
   * `up_cmds` - a list of commands to run to configure the interface
@@ -33,6 +34,7 @@ defmodule VintageNet.Interface.RawConfig do
             require_interface: true,
             retry_millis: 30_000,
             files: [],
+            restart_strategy: :one_for_all,
             child_specs: [],
             up_cmd_millis: 5_000,
             up_cmds: [],
@@ -47,6 +49,7 @@ defmodule VintageNet.Interface.RawConfig do
           require_interface: boolean(),
           retry_millis: non_neg_integer(),
           files: [file_contents()],
+          restart_strategy: Supervisor.strategy(),
           child_specs: [Supervisor.child_spec()],
           up_cmd_millis: non_neg_integer(),
           up_cmds: [command()],

--- a/lib/vintage_net/interface/supervisor.ex
+++ b/lib/vintage_net/interface/supervisor.ex
@@ -25,20 +25,20 @@ defmodule VintageNet.Interface.Supervisor do
   @doc """
   Add child_specs provided by technologies to supervision
   """
-  @spec set_technology(VintageNet.ifname(), [
+  @spec set_technology(VintageNet.ifname(), Supervisor.strategy(), [
           :supervisor.child_spec() | {module(), term()} | module()
         ]) ::
           :ok
-  def set_technology(ifname, []) do
+  def set_technology(ifname, _restart_strategy, []) do
     clear_technology(ifname)
   end
 
-  def set_technology(ifname, child_specs) when is_list(child_specs) do
+  def set_technology(ifname, restart_strategy, child_specs) when is_list(child_specs) do
     clear_technology(ifname)
 
     supervisor_spec = %{
       id: :technology,
-      start: {Supervisor, :start_link, [child_specs, [strategy: :one_for_all]]}
+      start: {Supervisor, :start_link, [child_specs, [strategy: restart_strategy]]}
     }
 
     {:ok, _pid} = Supervisor.start_child(via_name(ifname), supervisor_spec)

--- a/lib/vintage_net/route/calculator.ex
+++ b/lib/vintage_net/route/calculator.ex
@@ -42,7 +42,7 @@ defmodule VintageNet.Route.Calculator do
   The entries are ordered so that List.myers_difference/2 can be used to
   minimize the routing table changes.
   """
-  @spec compute(table_indices(), interface_infos(), Classification.prioritization()) ::
+  @spec compute(table_indices(), interface_infos(), [Classification.prioritization()]) ::
           {table_indices(), entries()}
   def compute(table_indices, infos, prioritization) do
     {new_table_indices, entries} =

--- a/lib/vintage_net/route_manager.ex
+++ b/lib/vintage_net/route_manager.ex
@@ -149,11 +149,15 @@ defmodule VintageNet.RouteManager do
 
   @impl true
   def handle_call({:clear_route, ifname}, _from, state) do
-    _ = Logger.info("RouteManager: clear_route #{ifname}")
-
     new_state =
-      %{state | interfaces: Map.delete(state.interfaces, ifname)}
-      |> update_route_tables()
+      if Map.has_key?(state.interfaces, ifname) do
+        _ = Logger.info("RouteManager: clear_route #{ifname}")
+
+        %{state | interfaces: Map.delete(state.interfaces, ifname)}
+        |> update_route_tables()
+      else
+        state
+      end
 
     {:reply, :ok, new_state}
   end


### PR DESCRIPTION
Seem commits for more details. I made these changes while working on `muontrap` updates, but they're not related to the updates. 