### PR TITLE
Only update_route_tables() to update properties

### DIFF
--- a/lib/vintage_net/route_manager.ex
+++ b/lib/vintage_net/route_manager.ex
@@ -106,16 +106,17 @@ defmodule VintageNet.RouteManager do
 
   @impl true
   def init(_args) do
-    state = %State{
-      prioritization: Classification.default_prioritization(),
-      interfaces: %{},
-      route_state: Calculator.init()
-    }
-
     # Fresh slate
     IPRoute.clear_all_routes()
     IPRoute.clear_all_rules(100..200)
-    VintageNet.PropertyTable.put(VintageNet, ["available_interfaces"], [])
+
+    state =
+      %State{
+        prioritization: Classification.default_prioritization(),
+        interfaces: %{},
+        route_state: Calculator.init()
+      }
+      |> update_route_tables()
 
     {:ok, state}
   end


### PR DESCRIPTION
I forgot this from my previous PR. This change is needed to fix an issue that was introduced with 081736b1e1cc02f0e70aab68a952dcc86ba788cc. The gratuitous clear_routes had a side effect of fixing a missing property from initialization. This routes initialization through update_route_tables() so this code is only maintained in one place.