### PR TITLE
 Fix posix error that was not wrapped in error tuple 

### DIFF
--- a/lib/vintage_net/interface/internet_tester.ex
+++ b/lib/vintage_net/interface/internet_tester.ex
@@ -30,6 +30,9 @@ defmodule VintageNet.Interface.InternetTester do
          {:ok, tcp} <- :gen_tcp.connect(dest_ip, @ping_port, [ip: src_ip], @ping_timeout) do
       _ = :gen_tcp.close(tcp)
       :ok
+    else
+      {:error, reason} -> {:error, reason}
+      posix_error -> {:error, posix_error}
     end
   end
 


### PR DESCRIPTION
@ConnorRigby This doesn't fix the error you were seeing, but I saw it when reviewing the code.