### PR TITLE
Add a LAN connectivity checker

### DIFF
--- a/lib/vintage_net/interface/internet_connectivity_checker.ex
+++ b/lib/vintage_net/interface/internet_connectivity_checker.ex
@@ -1,10 +1,18 @@
-defmodule VintageNet.Interface.ConnectivityChecker do
+defmodule VintageNet.Interface.InternetConnectivityChecker do
   use GenServer
   require Logger
 
   alias VintageNet.{PropertyTable, RouteManager}
   alias VintageNet.Interface.InternetTester
 
+  @moduledoc """
+  This GenServer monitors a network interface for Internet connectivity
+
+  Internet connectivity is determined by reachability to an IP address.
+  If that address is reachable then other this updates a property to
+  reflect that. Otherwise, the network interface is assumed to merely
+  have LAN connectivity if it's up.
+  """
   @min_interval 500
   @max_interval 30_000
   @max_fails_in_a_row 3

--- a/lib/vintage_net/interface/internet_tester.ex
+++ b/lib/vintage_net/interface/internet_tester.ex
@@ -2,8 +2,8 @@ defmodule VintageNet.Interface.InternetTester do
   @moduledoc """
   This module contains functions for testing whether the Internet is available.
 
-  See the ConnectivityChecker for a GenServer that checks on regular intervals
-  and updates VintageNet properties as needed.
+  See the InternetConnectivityChecker for a GenServer that checks on regular
+  intervals and updates VintageNet properties as needed.
   """
   @ping_port 80
   @ping_timeout 5_000

--- a/lib/vintage_net/interface/lan_connectivity_checker.ex
+++ b/lib/vintage_net/interface/lan_connectivity_checker.ex
@@ -1,0 +1,90 @@
+defmodule VintageNet.Interface.LANConnectivityChecker do
+  use GenServer
+  require Logger
+
+  alias VintageNet.{PropertyTable, RouteManager}
+
+  @moduledoc """
+  This GenServer monitors a network interface for LAN connectivity
+
+  Currently LAN connectivity simply looks to see if it's possible to
+  send a packet on the interface. It might or might not get to the
+  desired destination on the LAN, but it won't obviously fail.
+
+  This is an alternative to the InternetConnectivityChecker that
+  actively monitors reachability to a host.
+  """
+
+  @doc """
+  Start the connectivity checker GenServer
+  """
+  @spec start_link(VintageNet.ifname()) :: GenServer.on_start()
+  def start_link(ifname) do
+    GenServer.start_link(__MODULE__, ifname)
+  end
+
+  @impl true
+  def init(ifname) do
+    state = %{ifname: ifname}
+    {:ok, state, {:continue, :continue}}
+  end
+
+  @impl true
+  def handle_continue(:continue, %{ifname: ifname} = state) do
+    VintageNet.subscribe(lower_up_property(ifname))
+
+    case VintageNet.get(lower_up_property(ifname)) do
+      true ->
+        set_connectivity(ifname, :lan)
+
+      _not_true ->
+        # If the physical layer isn't up, don't start polling until
+        # we're notified that it is available.
+        set_connectivity(ifname, :disconnected)
+    end
+
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_info(
+        {VintageNet, ["interface", ifname, "lower_up"], _old_value, false, _meta},
+        %{ifname: ifname} = state
+      ) do
+    # Physical layer is down. We're definitely disconnected.
+    set_connectivity(ifname, :disconnected)
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_info(
+        {VintageNet, ["interface", ifname, "lower_up"], _old_value, true, _meta},
+        %{ifname: ifname} = state
+      ) do
+    # Physical layer is up. Optimistically assume that the LAN is accessible.
+
+    # NOTE: Consider triggering based on whether the interface has an IP address or not.
+    set_connectivity(ifname, :lan)
+
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_info(
+        {VintageNet, ["interface", ifname, "lower_up"], old_value, nil, _meta},
+        %{ifname: ifname} = state
+      ) do
+    # The interface was completely removed!
+    if old_value, do: set_connectivity(ifname, :disconnected)
+    {:noreply, state}
+  end
+
+  defp set_connectivity(ifname, connectivity) do
+    RouteManager.set_connection_status(ifname, connectivity)
+    PropertyTable.put(VintageNet, ["interface", ifname, "connection"], connectivity)
+  end
+
+  defp lower_up_property(ifname) do
+    ["interface", ifname, "lower_up"]
+  end
+end

--- a/lib/vintage_net/technology/ethernet.ex
+++ b/lib/vintage_net/technology/ethernet.ex
@@ -24,7 +24,7 @@ defmodule VintageNet.Technology.Ethernet do
          {network_interfaces_path,
           ConfigToInterfaces.config_to_interfaces_contents(ifname, config)}
        ],
-       child_specs: [{VintageNet.Interface.ConnectivityChecker, ifname}],
+       child_specs: [{VintageNet.Interface.InternetConnectivityChecker, ifname}],
        # ifup hangs forever until Ethernet is plugged in
        up_cmd_millis: 60_000,
        up_cmds: [

--- a/lib/vintage_net/technology/wifi.ex
+++ b/lib/vintage_net/technology/wifi.ex
@@ -79,7 +79,7 @@ defmodule VintageNet.Technology.WiFi do
            files: files ++ udhcpd_files,
            cleanup_files: control_interface_paths,
            child_specs: [
-             {VintageNet.Interface.ConnectivityChecker, ifname},
+             {VintageNet.Interface.LANConnectivityChecker, ifname},
              {WPASupplicant,
               ifname: ifname, control_path: control_interface_dir, ap_mode: ap_mode}
            ],
@@ -97,7 +97,7 @@ defmodule VintageNet.Technology.WiFi do
            files: files,
            cleanup_files: control_interface_paths,
            child_specs: [
-             {VintageNet.Interface.ConnectivityChecker, ifname},
+             {VintageNet.Interface.InternetConnectivityChecker, ifname},
              {WPASupplicant,
               ifname: ifname, control_path: control_interface_dir, ap_mode: ap_mode}
            ],
@@ -136,7 +136,7 @@ defmodule VintageNet.Technology.WiFi do
        source_config: %{type: __MODULE__},
        files: files,
        child_specs: [
-         {VintageNet.Interface.ConnectivityChecker, ifname},
+         {VintageNet.Interface.InternetConnectivityChecker, ifname},
          {WPASupplicant, ifname: ifname, control_path: control_interface_dir, ap_mode: false}
        ],
        up_cmds: up_cmds,

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -3,4 +3,6 @@ File.rm_rf!("test/tmp")
 # VintageNet.InterfacesMonitor only works on Linux
 exclude = if :os.type() == {:unix, :linux}, do: [], else: [requires_interfaces_monitor: true]
 
-ExUnit.start(exclude: exclude)
+# Networking support has enough pieces that are singleton in nature
+# that parallel running of tests can't be done.
+ExUnit.start(exclude: exclude, max_cases: 1)

--- a/test/vintage_net/interface/internet_connectivity_checker_test.exs
+++ b/test/vintage_net/interface/internet_connectivity_checker_test.exs
@@ -1,0 +1,42 @@
+defmodule VintageNet.Interface.InternetConnectivityCheckerTest do
+  use ExUnit.Case, async: true
+
+  alias VintageNet.Interface.InternetConnectivityChecker
+
+  test "disconnected interface" do
+    property = ["interface", "disconnected_interface", "connection"]
+    VintageNet.subscribe(property)
+
+    start_supervised!({InternetConnectivityChecker, "disconnected_interface"})
+
+    assert_receive {VintageNet, ^property, _old_value, :disconnected, _meta}, 1_000
+  end
+
+  @tag :requires_interfaces_monitor
+  test "internet connected interface" do
+    ifname = get_ifname()
+    property = ["interface", ifname, "connection"]
+    VintageNet.subscribe(property)
+
+    start_supervised!({InternetConnectivityChecker, ifname})
+
+    assert_receive {VintageNet, ^property, _old_value, :internet, _meta}, 1_000
+  end
+
+  defp get_ifname() do
+    case :inet.getifaddrs() do
+      {:ok, addrs} ->
+        addrs
+        |> Enum.filter(&filter_interfaces/1)
+        |> List.first()
+        |> elem(0)
+        |> to_string()
+    end
+  end
+
+  defp filter_interfaces({[?l, ?o | _anything], _}), do: false
+
+  defp filter_interfaces({_ifname, fields}) do
+    Enum.member?(fields[:flags], :up) and fields[:addr] != nil
+  end
+end

--- a/test/vintage_net/interface/lan_connectivity_checker_test.exs
+++ b/test/vintage_net/interface/lan_connectivity_checker_test.exs
@@ -1,26 +1,27 @@
-defmodule VintageNet.Interface.ConnectivityCheckerTest do
+defmodule VintageNet.Interface.LANConnectivityCheckerTest do
   use ExUnit.Case, async: true
 
-  alias VintageNet.Interface.ConnectivityChecker
+  alias VintageNet.Interface.LANConnectivityChecker
 
   test "disconnected interface" do
     property = ["interface", "disconnected_interface", "connection"]
     VintageNet.subscribe(property)
 
-    start_supervised!({ConnectivityChecker, "disconnected_interface"})
+    start_supervised!({LANConnectivityChecker, "disconnected_interface"})
 
-    assert_receive {VintageNet, property, _old_value, :disconnected, _meta}, 1_000
+    assert_receive {VintageNet, ^property, _old_value, :disconnected, _meta}, 1_000
   end
 
   @tag :requires_interfaces_monitor
-  test "internet connected interface" do
+  test "lan connected interface" do
     ifname = get_ifname()
     property = ["interface", ifname, "connection"]
     VintageNet.subscribe(property)
 
-    start_supervised!({ConnectivityChecker, ifname})
+    start_supervised!({LANConnectivityChecker, ifname})
 
-    assert_receive {VintageNet, property, _old_value, :internet, _meta}, 1_000
+    assert_receive {VintageNet, ^property, _old_value, :lan, _meta}, 1_000
+    refute_receive {VintageNet, ^property, _old_value, :internet, _meta}
   end
 
   defp get_ifname() do

--- a/test/vintage_net/interface/lan_connectivity_checker_test.exs
+++ b/test/vintage_net/interface/lan_connectivity_checker_test.exs
@@ -4,10 +4,10 @@ defmodule VintageNet.Interface.LANConnectivityCheckerTest do
   alias VintageNet.Interface.LANConnectivityChecker
 
   test "disconnected interface" do
-    property = ["interface", "disconnected_interface", "connection"]
+    property = ["interface", "disconnected_interface2", "connection"]
     VintageNet.subscribe(property)
 
-    start_supervised!({LANConnectivityChecker, "disconnected_interface"})
+    start_supervised!({LANConnectivityChecker, "disconnected_interface2"})
 
     assert_receive {VintageNet, ^property, _old_value, :disconnected, _meta}, 1_000
   end

--- a/test/vintage_net/technology/ethernet_test.exs
+++ b/test/vintage_net/technology/ethernet_test.exs
@@ -11,7 +11,7 @@ defmodule VintageNet.Technology.EthernetTest do
       ifname: "eth0",
       type: VintageNet.Technology.Ethernet,
       source_config: input,
-      child_specs: [{VintageNet.Interface.ConnectivityChecker, "eth0"}],
+      child_specs: [{VintageNet.Interface.InternetConnectivityChecker, "eth0"}],
       files: [
         {"/tmp/vintage_net/network_interfaces.eth0", dhcp_interface("eth0", "unittest")}
       ],
@@ -53,7 +53,7 @@ defmodule VintageNet.Technology.EthernetTest do
       ifname: "eth0",
       type: VintageNet.Technology.Ethernet,
       source_config: input,
-      child_specs: [{VintageNet.Interface.ConnectivityChecker, "eth0"}],
+      child_specs: [{VintageNet.Interface.InternetConnectivityChecker, "eth0"}],
       files: [{"/tmp/vintage_net/network_interfaces.eth0", interfaces_content}],
       up_cmd_millis: 60_000,
       up_cmds: [

--- a/test/vintage_net/technology/wifi_test.exs
+++ b/test/vintage_net/technology/wifi_test.exs
@@ -93,7 +93,7 @@ defmodule VintageNet.Technology.WiFiTest do
       type: VintageNet.Technology.WiFi,
       source_config: normalize_config(input),
       child_specs: [
-        {VintageNet.Interface.ConnectivityChecker, "wlan0"},
+        {VintageNet.Interface.InternetConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
          [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant", ap_mode: false]}
       ],
@@ -144,7 +144,7 @@ defmodule VintageNet.Technology.WiFiTest do
       type: VintageNet.Technology.WiFi,
       source_config: normalize_config(input),
       child_specs: [
-        {VintageNet.Interface.ConnectivityChecker, "wlan0"},
+        {VintageNet.Interface.InternetConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
          [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant", ap_mode: false]}
       ],
@@ -194,7 +194,7 @@ defmodule VintageNet.Technology.WiFiTest do
       type: VintageNet.Technology.WiFi,
       source_config: normalize_config(input),
       child_specs: [
-        {VintageNet.Interface.ConnectivityChecker, "wlan0"},
+        {VintageNet.Interface.InternetConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
          [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant", ap_mode: false]}
       ],
@@ -246,7 +246,7 @@ defmodule VintageNet.Technology.WiFiTest do
       type: VintageNet.Technology.WiFi,
       source_config: normalize_config(input),
       child_specs: [
-        {VintageNet.Interface.ConnectivityChecker, "wlan0"},
+        {VintageNet.Interface.InternetConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
          [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant", ap_mode: false]}
       ],
@@ -303,7 +303,7 @@ defmodule VintageNet.Technology.WiFiTest do
       type: VintageNet.Technology.WiFi,
       source_config: normalize_config(input),
       child_specs: [
-        {VintageNet.Interface.ConnectivityChecker, "wlan0"},
+        {VintageNet.Interface.InternetConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
          [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant", ap_mode: false]}
       ],
@@ -362,7 +362,7 @@ defmodule VintageNet.Technology.WiFiTest do
       type: VintageNet.Technology.WiFi,
       source_config: normalize_config(input),
       child_specs: [
-        {VintageNet.Interface.ConnectivityChecker, "wlan0"},
+        {VintageNet.Interface.InternetConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
          [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant", ap_mode: false]}
       ],
@@ -423,7 +423,7 @@ defmodule VintageNet.Technology.WiFiTest do
       type: VintageNet.Technology.WiFi,
       source_config: normalize_config(input),
       child_specs: [
-        {VintageNet.Interface.ConnectivityChecker, "wlan0"},
+        {VintageNet.Interface.InternetConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
          [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant", ap_mode: false]}
       ],
@@ -487,7 +487,7 @@ defmodule VintageNet.Technology.WiFiTest do
       type: VintageNet.Technology.WiFi,
       source_config: normalize_config(input),
       child_specs: [
-        {VintageNet.Interface.ConnectivityChecker, "wlan0"},
+        {VintageNet.Interface.InternetConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
          [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant", ap_mode: false]}
       ],
@@ -551,7 +551,7 @@ defmodule VintageNet.Technology.WiFiTest do
       type: VintageNet.Technology.WiFi,
       source_config: normalize_config(input),
       child_specs: [
-        {VintageNet.Interface.ConnectivityChecker, "wlan0"},
+        {VintageNet.Interface.InternetConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
          [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant", ap_mode: false]}
       ],
@@ -617,7 +617,7 @@ defmodule VintageNet.Technology.WiFiTest do
       type: VintageNet.Technology.WiFi,
       source_config: normalize_config(input),
       child_specs: [
-        {VintageNet.Interface.ConnectivityChecker, "wlan0"},
+        {VintageNet.Interface.InternetConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
          [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant", ap_mode: false]}
       ],
@@ -681,7 +681,7 @@ defmodule VintageNet.Technology.WiFiTest do
       type: VintageNet.Technology.WiFi,
       source_config: normalize_config(input),
       child_specs: [
-        {VintageNet.Interface.ConnectivityChecker, "wlan0"},
+        {VintageNet.Interface.InternetConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
          [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant", ap_mode: false]}
       ],
@@ -747,7 +747,7 @@ defmodule VintageNet.Technology.WiFiTest do
       type: VintageNet.Technology.WiFi,
       source_config: normalize_config(input),
       child_specs: [
-        {VintageNet.Interface.ConnectivityChecker, "wlan0"},
+        {VintageNet.Interface.InternetConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
          [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant", ap_mode: false]}
       ],
@@ -810,7 +810,7 @@ defmodule VintageNet.Technology.WiFiTest do
       type: VintageNet.Technology.WiFi,
       source_config: normalize_config(input),
       child_specs: [
-        {VintageNet.Interface.ConnectivityChecker, "wlan0"},
+        {VintageNet.Interface.InternetConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
          [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant", ap_mode: false]}
       ],
@@ -868,7 +868,7 @@ defmodule VintageNet.Technology.WiFiTest do
       type: VintageNet.Technology.WiFi,
       source_config: normalize_config(input),
       child_specs: [
-        {VintageNet.Interface.ConnectivityChecker, "wlan0"},
+        {VintageNet.Interface.InternetConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
          [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant", ap_mode: false]}
       ],
@@ -930,7 +930,7 @@ defmodule VintageNet.Technology.WiFiTest do
       type: VintageNet.Technology.WiFi,
       source_config: normalize_config(input),
       child_specs: [
-        {VintageNet.Interface.ConnectivityChecker, "wlan0"},
+        {VintageNet.Interface.InternetConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
          [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant", ap_mode: false]}
       ],
@@ -989,7 +989,7 @@ defmodule VintageNet.Technology.WiFiTest do
       type: VintageNet.Technology.WiFi,
       source_config: normalize_config(input),
       child_specs: [
-        {VintageNet.Interface.ConnectivityChecker, "wlan0"},
+        {VintageNet.Interface.InternetConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
          [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant", ap_mode: false]}
       ],
@@ -1042,7 +1042,7 @@ defmodule VintageNet.Technology.WiFiTest do
       type: VintageNet.Technology.WiFi,
       source_config: normalize_config(input),
       child_specs: [
-        {VintageNet.Interface.ConnectivityChecker, "wlan0"},
+        {VintageNet.Interface.InternetConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
          [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant", ap_mode: false]}
       ],
@@ -1096,7 +1096,7 @@ defmodule VintageNet.Technology.WiFiTest do
       type: VintageNet.Technology.WiFi,
       source_config: normalize_config(input),
       child_specs: [
-        {VintageNet.Interface.ConnectivityChecker, "wlan0"},
+        {VintageNet.Interface.InternetConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
          [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant", ap_mode: true]}
       ],
@@ -1172,7 +1172,7 @@ defmodule VintageNet.Technology.WiFiTest do
       type: VintageNet.Technology.WiFi,
       source_config: normalize_config(input),
       child_specs: [
-        {VintageNet.Interface.ConnectivityChecker, "wlan0"},
+        {VintageNet.Interface.InternetConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
          [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant", ap_mode: false]}
       ],
@@ -1249,7 +1249,7 @@ defmodule VintageNet.Technology.WiFiTest do
       type: VintageNet.Technology.WiFi,
       source_config: normalize_config(input),
       child_specs: [
-        {VintageNet.Interface.ConnectivityChecker, "wlan0"},
+        {VintageNet.Interface.InternetConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
          [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant", ap_mode: false]}
       ],
@@ -1327,7 +1327,7 @@ defmodule VintageNet.Technology.WiFiTest do
       type: VintageNet.Technology.WiFi,
       source_config: normalize_config(input),
       child_specs: [
-        {VintageNet.Interface.ConnectivityChecker, "wlan0"},
+        {VintageNet.Interface.LANConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
          [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant", ap_mode: true]}
       ],


### PR DESCRIPTION
This is a simplified version of the Internet-aware connectivity checker
for network configurations where there's no chance of an internet
connection and doing any kind of polling is silly. This eliminates
warnings in the logs when the Internet isn't found.