### PR TITLE
Support globally adding MuonTrap options

### DIFF
--- a/lib/vintage_net/command.ex
+++ b/lib/vintage_net/command.ex
@@ -18,9 +18,20 @@ defmodule VintageNet.Command do
   @spec muon_cmd(binary(), [binary()], keyword()) ::
           {Collectable.t(), exit_status :: non_neg_integer()}
   def muon_cmd(command, args, opts \\ []) do
-    new_opts = force_path_env(opts)
+    new_opts = opts |> force_path_env() |> add_muon_options()
 
     MuonTrap.cmd(command, args, new_opts)
+  end
+
+  @doc """
+  Add common options for MuonTrap
+  """
+  @spec add_muon_options(keyword()) :: keyword()
+  def add_muon_options(opts) do
+    Keyword.merge(
+      opts,
+      Application.get_env(:vintage_net, :muontrap_options)
+    )
   end
 
   defp force_path_env(opts) do

--- a/mix.exs
+++ b/mix.exs
@@ -51,7 +51,10 @@ defmodule VintageNet.MixProject do
         persistence_dir: "/root/vintage_net",
         persistence_secret: "obfuscate_things",
         internet_host: {1, 1, 1, 1},
-        regulatory_domain: "00"
+        regulatory_domain: "00",
+        # Contain processes in cgroups by setting to:
+        #   [cgroup_base: "vintage_net", cgroup_controllers: ["cpu"]]
+        muontrap_options: []
       ],
       extra_applications: [:logger],
       mod: {VintageNet.Application, []}


### PR DESCRIPTION
This allows a device to run all of the networking-related programs under a
specific uid/gid or in a cgroup. It's also useful for testing.