### PR TITLE
Start the wpa_supplicant from WpaSupplicant

### DIFF
--- a/lib/vintage_net/technology/wifi.ex
+++ b/lib/vintage_net/technology/wifi.ex
@@ -34,7 +34,6 @@ defmodule VintageNet.Technology.WiFi do
     ifup = Keyword.fetch!(opts, :bin_ifup)
     ifdown = Keyword.fetch!(opts, :bin_ifdown)
     wpa_supplicant = Keyword.fetch!(opts, :bin_wpa_supplicant)
-    killall = Keyword.fetch!(opts, :bin_killall)
     tmpdir = Keyword.fetch!(opts, :tmpdir)
     regulatory_domain = Keyword.fetch!(opts, :regulatory_domain)
 
@@ -59,14 +58,11 @@ defmodule VintageNet.Technology.WiFi do
 
     up_cmds = [
       {:run_ignore_errors, ifdown, ["-i", network_interfaces_path, ifname]},
-      {:run_ignore_errors, killall, ["-q", "wpa_supplicant"]},
-      {:run, wpa_supplicant, ["-B", "-i", ifname, "-c", wpa_supplicant_conf_path, "-dd"]},
       {:run, ifup, ["-i", network_interfaces_path, ifname]}
     ]
 
     down_cmds = [
-      {:run, ifdown, ["-i", network_interfaces_path, ifname]},
-      {:run, killall, ["-q", "wpa_supplicant"]}
+      {:run, ifdown, ["-i", network_interfaces_path, ifname]}
     ]
 
     case maybe_add_udhcpd(ifname, normalized_config, opts) do
@@ -81,7 +77,11 @@ defmodule VintageNet.Technology.WiFi do
            child_specs: [
              {VintageNet.Interface.LANConnectivityChecker, ifname},
              {WPASupplicant,
-              ifname: ifname, control_path: control_interface_dir, ap_mode: ap_mode}
+              wpa_supplicant: wpa_supplicant,
+              ifname: ifname,
+              wpa_supplicant_conf_path: wpa_supplicant_conf_path,
+              control_path: control_interface_dir,
+              ap_mode: ap_mode}
            ],
            up_cmds: up_cmds ++ udhcpd_up_cmds,
            up_cmd_millis: 60_000,
@@ -99,7 +99,11 @@ defmodule VintageNet.Technology.WiFi do
            child_specs: [
              {VintageNet.Interface.InternetConnectivityChecker, ifname},
              {WPASupplicant,
-              ifname: ifname, control_path: control_interface_dir, ap_mode: ap_mode}
+              wpa_supplicant: wpa_supplicant,
+              ifname: ifname,
+              wpa_supplicant_conf_path: wpa_supplicant_conf_path,
+              control_path: control_interface_dir,
+              ap_mode: ap_mode}
            ],
            up_cmds: up_cmds,
            up_cmd_millis: 60_000,
@@ -110,7 +114,6 @@ defmodule VintageNet.Technology.WiFi do
 
   def to_raw_config(ifname, %{type: __MODULE__} = config, opts) do
     wpa_supplicant = Keyword.fetch!(opts, :bin_wpa_supplicant)
-    killall = Keyword.fetch!(opts, :bin_killall)
     tmpdir = Keyword.fetch!(opts, :tmpdir)
 
     wpa_supplicant_conf_path = Path.join(tmpdir, "wpa_supplicant.conf.#{ifname}")
@@ -121,14 +124,6 @@ defmodule VintageNet.Technology.WiFi do
       {wpa_supplicant_conf_path, "ctrl_interface=#{control_interface_dir}"}
     ]
 
-    up_cmds = [
-      {:run, wpa_supplicant, ["-B", "-i", ifname, "-c", wpa_supplicant_conf_path, "-dd"]}
-    ]
-
-    down_cmds = [
-      {:run, killall, ["-q", "wpa_supplicant"]}
-    ]
-
     {:ok,
      %RawConfig{
        ifname: ifname,
@@ -137,10 +132,13 @@ defmodule VintageNet.Technology.WiFi do
        files: files,
        child_specs: [
          {VintageNet.Interface.InternetConnectivityChecker, ifname},
-         {WPASupplicant, ifname: ifname, control_path: control_interface_dir, ap_mode: false}
+         {WPASupplicant,
+          wpa_supplicant: wpa_supplicant,
+          ifname: ifname,
+          wpa_supplicant_conf_path: wpa_supplicant_conf_path,
+          control_path: control_interface_dir,
+          ap_mode: false}
        ],
-       up_cmds: up_cmds,
-       down_cmds: down_cmds,
        cleanup_files: control_interface_paths
      }}
   end

--- a/lib/vintage_net/wifi/wpa_supplicant.ex
+++ b/lib/vintage_net/wifi/wpa_supplicant.ex
@@ -299,7 +299,7 @@ defmodule VintageNet.WiFi.WPASupplicant do
         # so all this to work, but with a penalty just in case the others show
         # up momentarily.
         Process.sleep(100)
-        Enum.filter(paths, &File.exists?/1)
+        {:ok, Enum.filter(paths, &File.exists?/1)}
 
       paths ->
         {:ok, paths}

--- a/test/vintage_net/technology/wifi_test.exs
+++ b/test/vintage_net/technology/wifi_test.exs
@@ -95,7 +95,13 @@ defmodule VintageNet.Technology.WiFiTest do
       child_specs: [
         {VintageNet.Interface.InternetConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
-         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant", ap_mode: false]}
+         [
+           wpa_supplicant: "wpa_supplicant",
+           ifname: "wlan0",
+           wpa_supplicant_conf_path: "/tmp/vintage_net/wpa_supplicant.conf.wlan0",
+           control_path: "/tmp/vintage_net/wpa_supplicant",
+           ap_mode: false
+         ]}
       ],
       files: [
         {"/tmp/vintage_net/network_interfaces.wlan0", dhcp_interface("wlan0", "unit_test")},
@@ -114,14 +120,10 @@ defmodule VintageNet.Technology.WiFiTest do
       up_cmds: [
         {:run_ignore_errors, "ifdown",
          ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]},
-        {:run_ignore_errors, "killall", ["-q", "wpa_supplicant"]},
-        {:run, "wpa_supplicant",
-         ["-B", "-i", "wlan0", "-c", "/tmp/vintage_net/wpa_supplicant.conf.wlan0", "-dd"]},
         {:run, "ifup", ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]}
       ],
       down_cmds: [
-        {:run, "ifdown", ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]},
-        {:run, "killall", ["-q", "wpa_supplicant"]}
+        {:run, "ifdown", ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]}
       ],
       cleanup_files: ["/tmp/vintage_net/wpa_supplicant/wlan0"]
     }
@@ -146,7 +148,13 @@ defmodule VintageNet.Technology.WiFiTest do
       child_specs: [
         {VintageNet.Interface.InternetConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
-         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant", ap_mode: false]}
+         [
+           wpa_supplicant: "wpa_supplicant",
+           ifname: "wlan0",
+           wpa_supplicant_conf_path: "/tmp/vintage_net/wpa_supplicant.conf.wlan0",
+           control_path: "/tmp/vintage_net/wpa_supplicant",
+           ap_mode: false
+         ]}
       ],
       files: [
         {"/tmp/vintage_net/network_interfaces.wlan0", dhcp_interface("wlan0", "unit_test")},
@@ -162,14 +170,10 @@ defmodule VintageNet.Technology.WiFiTest do
       up_cmds: [
         {:run_ignore_errors, "ifdown",
          ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]},
-        {:run_ignore_errors, "killall", ["-q", "wpa_supplicant"]},
-        {:run, "wpa_supplicant",
-         ["-B", "-i", "wlan0", "-c", "/tmp/vintage_net/wpa_supplicant.conf.wlan0", "-dd"]},
         {:run, "ifup", ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]}
       ],
       down_cmds: [
-        {:run, "ifdown", ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]},
-        {:run, "killall", ["-q", "wpa_supplicant"]}
+        {:run, "ifdown", ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]}
       ],
       cleanup_files: ["/tmp/vintage_net/wpa_supplicant/wlan0"]
     }
@@ -196,7 +200,13 @@ defmodule VintageNet.Technology.WiFiTest do
       child_specs: [
         {VintageNet.Interface.InternetConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
-         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant", ap_mode: false]}
+         [
+           wpa_supplicant: "wpa_supplicant",
+           ifname: "wlan0",
+           wpa_supplicant_conf_path: "/tmp/vintage_net/wpa_supplicant.conf.wlan0",
+           control_path: "/tmp/vintage_net/wpa_supplicant",
+           ap_mode: false
+         ]}
       ],
       files: [
         {"/tmp/vintage_net/network_interfaces.wlan0", dhcp_interface("wlan0", "unit_test")},
@@ -215,14 +225,10 @@ defmodule VintageNet.Technology.WiFiTest do
       up_cmds: [
         {:run_ignore_errors, "ifdown",
          ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]},
-        {:run_ignore_errors, "killall", ["-q", "wpa_supplicant"]},
-        {:run, "wpa_supplicant",
-         ["-B", "-i", "wlan0", "-c", "/tmp/vintage_net/wpa_supplicant.conf.wlan0", "-dd"]},
         {:run, "ifup", ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]}
       ],
       down_cmds: [
-        {:run, "ifdown", ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]},
-        {:run, "killall", ["-q", "wpa_supplicant"]}
+        {:run, "ifdown", ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]}
       ],
       cleanup_files: ["/tmp/vintage_net/wpa_supplicant/wlan0"]
     }
@@ -248,7 +254,13 @@ defmodule VintageNet.Technology.WiFiTest do
       child_specs: [
         {VintageNet.Interface.InternetConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
-         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant", ap_mode: false]}
+         [
+           wpa_supplicant: "wpa_supplicant",
+           ifname: "wlan0",
+           wpa_supplicant_conf_path: "/tmp/vintage_net/wpa_supplicant.conf.wlan0",
+           control_path: "/tmp/vintage_net/wpa_supplicant",
+           ap_mode: false
+         ]}
       ],
       files: [
         {"/tmp/vintage_net/network_interfaces.wlan0", dhcp_interface("wlan0", "unit_test")},
@@ -266,14 +278,10 @@ defmodule VintageNet.Technology.WiFiTest do
       up_cmds: [
         {:run_ignore_errors, "ifdown",
          ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]},
-        {:run_ignore_errors, "killall", ["-q", "wpa_supplicant"]},
-        {:run, "wpa_supplicant",
-         ["-B", "-i", "wlan0", "-c", "/tmp/vintage_net/wpa_supplicant.conf.wlan0", "-dd"]},
         {:run, "ifup", ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]}
       ],
       down_cmds: [
-        {:run, "ifdown", ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]},
-        {:run, "killall", ["-q", "wpa_supplicant"]}
+        {:run, "ifdown", ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]}
       ],
       cleanup_files: ["/tmp/vintage_net/wpa_supplicant/wlan0"]
     }
@@ -305,7 +313,13 @@ defmodule VintageNet.Technology.WiFiTest do
       child_specs: [
         {VintageNet.Interface.InternetConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
-         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant", ap_mode: false]}
+         [
+           wpa_supplicant: "wpa_supplicant",
+           ifname: "wlan0",
+           wpa_supplicant_conf_path: "/tmp/vintage_net/wpa_supplicant.conf.wlan0",
+           control_path: "/tmp/vintage_net/wpa_supplicant",
+           ap_mode: false
+         ]}
       ],
       files: [
         {"/tmp/vintage_net/network_interfaces.wlan0", dhcp_interface("wlan0", "unit_test")},
@@ -329,14 +343,10 @@ defmodule VintageNet.Technology.WiFiTest do
       up_cmds: [
         {:run_ignore_errors, "ifdown",
          ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]},
-        {:run_ignore_errors, "killall", ["-q", "wpa_supplicant"]},
-        {:run, "wpa_supplicant",
-         ["-B", "-i", "wlan0", "-c", "/tmp/vintage_net/wpa_supplicant.conf.wlan0", "-dd"]},
         {:run, "ifup", ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]}
       ],
       down_cmds: [
-        {:run, "ifdown", ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]},
-        {:run, "killall", ["-q", "wpa_supplicant"]}
+        {:run, "ifdown", ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]}
       ],
       cleanup_files: ["/tmp/vintage_net/wpa_supplicant/wlan0"]
     }
@@ -364,7 +374,13 @@ defmodule VintageNet.Technology.WiFiTest do
       child_specs: [
         {VintageNet.Interface.InternetConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
-         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant", ap_mode: false]}
+         [
+           wpa_supplicant: "wpa_supplicant",
+           ifname: "wlan0",
+           wpa_supplicant_conf_path: "/tmp/vintage_net/wpa_supplicant.conf.wlan0",
+           control_path: "/tmp/vintage_net/wpa_supplicant",
+           ap_mode: false
+         ]}
       ],
       files: [
         {"/tmp/vintage_net/network_interfaces.wlan0", dhcp_interface("wlan0", "unit_test")},
@@ -384,14 +400,10 @@ defmodule VintageNet.Technology.WiFiTest do
       up_cmds: [
         {:run_ignore_errors, "ifdown",
          ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]},
-        {:run_ignore_errors, "killall", ["-q", "wpa_supplicant"]},
-        {:run, "wpa_supplicant",
-         ["-B", "-i", "wlan0", "-c", "/tmp/vintage_net/wpa_supplicant.conf.wlan0", "-dd"]},
         {:run, "ifup", ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]}
       ],
       down_cmds: [
-        {:run, "ifdown", ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]},
-        {:run, "killall", ["-q", "wpa_supplicant"]}
+        {:run, "ifdown", ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]}
       ],
       cleanup_files: ["/tmp/vintage_net/wpa_supplicant/wlan0"]
     }
@@ -425,7 +437,13 @@ defmodule VintageNet.Technology.WiFiTest do
       child_specs: [
         {VintageNet.Interface.InternetConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
-         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant", ap_mode: false]}
+         [
+           wpa_supplicant: "wpa_supplicant",
+           ifname: "wlan0",
+           wpa_supplicant_conf_path: "/tmp/vintage_net/wpa_supplicant.conf.wlan0",
+           control_path: "/tmp/vintage_net/wpa_supplicant",
+           ap_mode: false
+         ]}
       ],
       files: [
         {"/tmp/vintage_net/network_interfaces.wlan0", dhcp_interface("wlan0", "unit_test")},
@@ -451,14 +469,10 @@ defmodule VintageNet.Technology.WiFiTest do
       up_cmds: [
         {:run_ignore_errors, "ifdown",
          ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]},
-        {:run_ignore_errors, "killall", ["-q", "wpa_supplicant"]},
-        {:run, "wpa_supplicant",
-         ["-B", "-i", "wlan0", "-c", "/tmp/vintage_net/wpa_supplicant.conf.wlan0", "-dd"]},
         {:run, "ifup", ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]}
       ],
       down_cmds: [
-        {:run, "ifdown", ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]},
-        {:run, "killall", ["-q", "wpa_supplicant"]}
+        {:run, "ifdown", ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]}
       ],
       cleanup_files: ["/tmp/vintage_net/wpa_supplicant/wlan0"]
     }
@@ -489,7 +503,13 @@ defmodule VintageNet.Technology.WiFiTest do
       child_specs: [
         {VintageNet.Interface.InternetConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
-         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant", ap_mode: false]}
+         [
+           wpa_supplicant: "wpa_supplicant",
+           ifname: "wlan0",
+           wpa_supplicant_conf_path: "/tmp/vintage_net/wpa_supplicant.conf.wlan0",
+           control_path: "/tmp/vintage_net/wpa_supplicant",
+           ap_mode: false
+         ]}
       ],
       files: [
         {"/tmp/vintage_net/network_interfaces.wlan0", dhcp_interface("wlan0", "unit_test")},
@@ -511,14 +531,10 @@ defmodule VintageNet.Technology.WiFiTest do
       up_cmds: [
         {:run_ignore_errors, "ifdown",
          ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]},
-        {:run_ignore_errors, "killall", ["-q", "wpa_supplicant"]},
-        {:run, "wpa_supplicant",
-         ["-B", "-i", "wlan0", "-c", "/tmp/vintage_net/wpa_supplicant.conf.wlan0", "-dd"]},
         {:run, "ifup", ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]}
       ],
       down_cmds: [
-        {:run, "ifdown", ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]},
-        {:run, "killall", ["-q", "wpa_supplicant"]}
+        {:run, "ifdown", ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]}
       ],
       cleanup_files: ["/tmp/vintage_net/wpa_supplicant/wlan0"]
     }
@@ -553,7 +569,13 @@ defmodule VintageNet.Technology.WiFiTest do
       child_specs: [
         {VintageNet.Interface.InternetConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
-         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant", ap_mode: false]}
+         [
+           wpa_supplicant: "wpa_supplicant",
+           ifname: "wlan0",
+           wpa_supplicant_conf_path: "/tmp/vintage_net/wpa_supplicant.conf.wlan0",
+           control_path: "/tmp/vintage_net/wpa_supplicant",
+           ap_mode: false
+         ]}
       ],
       files: [
         {"/tmp/vintage_net/network_interfaces.wlan0", dhcp_interface("wlan0", "unit_test")},
@@ -579,14 +601,10 @@ defmodule VintageNet.Technology.WiFiTest do
       up_cmds: [
         {:run_ignore_errors, "ifdown",
          ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]},
-        {:run_ignore_errors, "killall", ["-q", "wpa_supplicant"]},
-        {:run, "wpa_supplicant",
-         ["-B", "-i", "wlan0", "-c", "/tmp/vintage_net/wpa_supplicant.conf.wlan0", "-dd"]},
         {:run, "ifup", ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]}
       ],
       down_cmds: [
-        {:run, "ifdown", ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]},
-        {:run, "killall", ["-q", "wpa_supplicant"]}
+        {:run, "ifdown", ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]}
       ],
       cleanup_files: ["/tmp/vintage_net/wpa_supplicant/wlan0"]
     }
@@ -619,7 +637,13 @@ defmodule VintageNet.Technology.WiFiTest do
       child_specs: [
         {VintageNet.Interface.InternetConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
-         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant", ap_mode: false]}
+         [
+           wpa_supplicant: "wpa_supplicant",
+           ifname: "wlan0",
+           wpa_supplicant_conf_path: "/tmp/vintage_net/wpa_supplicant.conf.wlan0",
+           control_path: "/tmp/vintage_net/wpa_supplicant",
+           ap_mode: false
+         ]}
       ],
       files: [
         {"/tmp/vintage_net/network_interfaces.wlan0", dhcp_interface("wlan0", "unit_test")},
@@ -644,14 +668,10 @@ defmodule VintageNet.Technology.WiFiTest do
       up_cmds: [
         {:run_ignore_errors, "ifdown",
          ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]},
-        {:run_ignore_errors, "killall", ["-q", "wpa_supplicant"]},
-        {:run, "wpa_supplicant",
-         ["-B", "-i", "wlan0", "-c", "/tmp/vintage_net/wpa_supplicant.conf.wlan0", "-dd"]},
         {:run, "ifup", ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]}
       ],
       down_cmds: [
-        {:run, "ifdown", ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]},
-        {:run, "killall", ["-q", "wpa_supplicant"]}
+        {:run, "ifdown", ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]}
       ],
       cleanup_files: ["/tmp/vintage_net/wpa_supplicant/wlan0"]
     }
@@ -683,7 +703,13 @@ defmodule VintageNet.Technology.WiFiTest do
       child_specs: [
         {VintageNet.Interface.InternetConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
-         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant", ap_mode: false]}
+         [
+           wpa_supplicant: "wpa_supplicant",
+           ifname: "wlan0",
+           wpa_supplicant_conf_path: "/tmp/vintage_net/wpa_supplicant.conf.wlan0",
+           control_path: "/tmp/vintage_net/wpa_supplicant",
+           ap_mode: false
+         ]}
       ],
       files: [
         {"/tmp/vintage_net/network_interfaces.wlan0", dhcp_interface("wlan0", "unit_test")},
@@ -707,14 +733,10 @@ defmodule VintageNet.Technology.WiFiTest do
       up_cmds: [
         {:run_ignore_errors, "ifdown",
          ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]},
-        {:run_ignore_errors, "killall", ["-q", "wpa_supplicant"]},
-        {:run, "wpa_supplicant",
-         ["-B", "-i", "wlan0", "-c", "/tmp/vintage_net/wpa_supplicant.conf.wlan0", "-dd"]},
         {:run, "ifup", ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]}
       ],
       down_cmds: [
-        {:run, "ifdown", ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]},
-        {:run, "killall", ["-q", "wpa_supplicant"]}
+        {:run, "ifdown", ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]}
       ],
       cleanup_files: ["/tmp/vintage_net/wpa_supplicant/wlan0"]
     }
@@ -749,7 +771,13 @@ defmodule VintageNet.Technology.WiFiTest do
       child_specs: [
         {VintageNet.Interface.InternetConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
-         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant", ap_mode: false]}
+         [
+           wpa_supplicant: "wpa_supplicant",
+           ifname: "wlan0",
+           wpa_supplicant_conf_path: "/tmp/vintage_net/wpa_supplicant.conf.wlan0",
+           control_path: "/tmp/vintage_net/wpa_supplicant",
+           ap_mode: false
+         ]}
       ],
       files: [
         {"/tmp/vintage_net/network_interfaces.wlan0", dhcp_interface("wlan0", "unit_test")},
@@ -776,14 +804,10 @@ defmodule VintageNet.Technology.WiFiTest do
       up_cmds: [
         {:run_ignore_errors, "ifdown",
          ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]},
-        {:run_ignore_errors, "killall", ["-q", "wpa_supplicant"]},
-        {:run, "wpa_supplicant",
-         ["-B", "-i", "wlan0", "-c", "/tmp/vintage_net/wpa_supplicant.conf.wlan0", "-dd"]},
         {:run, "ifup", ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]}
       ],
       down_cmds: [
-        {:run, "ifdown", ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]},
-        {:run, "killall", ["-q", "wpa_supplicant"]}
+        {:run, "ifdown", ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]}
       ],
       cleanup_files: ["/tmp/vintage_net/wpa_supplicant/wlan0"]
     }
@@ -812,7 +836,13 @@ defmodule VintageNet.Technology.WiFiTest do
       child_specs: [
         {VintageNet.Interface.InternetConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
-         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant", ap_mode: false]}
+         [
+           wpa_supplicant: "wpa_supplicant",
+           ifname: "wlan0",
+           wpa_supplicant_conf_path: "/tmp/vintage_net/wpa_supplicant.conf.wlan0",
+           control_path: "/tmp/vintage_net/wpa_supplicant",
+           ap_mode: false
+         ]}
       ],
       files: [
         {"/tmp/vintage_net/network_interfaces.wlan0", dhcp_interface("wlan0", "unit_test")},
@@ -833,14 +863,10 @@ defmodule VintageNet.Technology.WiFiTest do
       up_cmds: [
         {:run_ignore_errors, "ifdown",
          ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]},
-        {:run_ignore_errors, "killall", ["-q", "wpa_supplicant"]},
-        {:run, "wpa_supplicant",
-         ["-B", "-i", "wlan0", "-c", "/tmp/vintage_net/wpa_supplicant.conf.wlan0", "-dd"]},
         {:run, "ifup", ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]}
       ],
       down_cmds: [
-        {:run, "ifdown", ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]},
-        {:run, "killall", ["-q", "wpa_supplicant"]}
+        {:run, "ifdown", ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]}
       ],
       cleanup_files: ["/tmp/vintage_net/wpa_supplicant/wlan0"]
     }
@@ -870,7 +896,13 @@ defmodule VintageNet.Technology.WiFiTest do
       child_specs: [
         {VintageNet.Interface.InternetConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
-         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant", ap_mode: false]}
+         [
+           wpa_supplicant: "wpa_supplicant",
+           ifname: "wlan0",
+           wpa_supplicant_conf_path: "/tmp/vintage_net/wpa_supplicant.conf.wlan0",
+           control_path: "/tmp/vintage_net/wpa_supplicant",
+           ap_mode: false
+         ]}
       ],
       files: [
         {"/tmp/vintage_net/network_interfaces.wlan0", dhcp_interface("wlan0", "unit_test")},
@@ -892,14 +924,10 @@ defmodule VintageNet.Technology.WiFiTest do
       up_cmds: [
         {:run_ignore_errors, "ifdown",
          ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]},
-        {:run_ignore_errors, "killall", ["-q", "wpa_supplicant"]},
-        {:run, "wpa_supplicant",
-         ["-B", "-i", "wlan0", "-c", "/tmp/vintage_net/wpa_supplicant.conf.wlan0", "-dd"]},
         {:run, "ifup", ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]}
       ],
       down_cmds: [
-        {:run, "ifdown", ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]},
-        {:run, "killall", ["-q", "wpa_supplicant"]}
+        {:run, "ifdown", ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]}
       ],
       cleanup_files: ["/tmp/vintage_net/wpa_supplicant/wlan0"]
     }
@@ -932,7 +960,13 @@ defmodule VintageNet.Technology.WiFiTest do
       child_specs: [
         {VintageNet.Interface.InternetConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
-         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant", ap_mode: false]}
+         [
+           wpa_supplicant: "wpa_supplicant",
+           ifname: "wlan0",
+           wpa_supplicant_conf_path: "/tmp/vintage_net/wpa_supplicant.conf.wlan0",
+           control_path: "/tmp/vintage_net/wpa_supplicant",
+           ap_mode: false
+         ]}
       ],
       files: [
         {"/tmp/vintage_net/network_interfaces.wlan0", dhcp_interface("wlan0", "unit_test")},
@@ -957,14 +991,10 @@ defmodule VintageNet.Technology.WiFiTest do
       up_cmds: [
         {:run_ignore_errors, "ifdown",
          ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]},
-        {:run_ignore_errors, "killall", ["-q", "wpa_supplicant"]},
-        {:run, "wpa_supplicant",
-         ["-B", "-i", "wlan0", "-c", "/tmp/vintage_net/wpa_supplicant.conf.wlan0", "-dd"]},
         {:run, "ifup", ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]}
       ],
       down_cmds: [
-        {:run, "ifdown", ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]},
-        {:run, "killall", ["-q", "wpa_supplicant"]}
+        {:run, "ifdown", ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]}
       ],
       cleanup_files: ["/tmp/vintage_net/wpa_supplicant/wlan0"]
     }
@@ -991,7 +1021,13 @@ defmodule VintageNet.Technology.WiFiTest do
       child_specs: [
         {VintageNet.Interface.InternetConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
-         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant", ap_mode: false]}
+         [
+           wpa_supplicant: "wpa_supplicant",
+           ifname: "wlan0",
+           wpa_supplicant_conf_path: "/tmp/vintage_net/wpa_supplicant.conf.wlan0",
+           control_path: "/tmp/vintage_net/wpa_supplicant",
+           ap_mode: false
+         ]}
       ],
       files: [
         {"/tmp/vintage_net/network_interfaces.wlan0", dhcp_interface("wlan0", "unit_test")},
@@ -1010,14 +1046,10 @@ defmodule VintageNet.Technology.WiFiTest do
       up_cmds: [
         {:run_ignore_errors, "ifdown",
          ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]},
-        {:run_ignore_errors, "killall", ["-q", "wpa_supplicant"]},
-        {:run, "wpa_supplicant",
-         ["-B", "-i", "wlan0", "-c", "/tmp/vintage_net/wpa_supplicant.conf.wlan0", "-dd"]},
         {:run, "ifup", ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]}
       ],
       down_cmds: [
-        {:run, "ifdown", ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]},
-        {:run, "killall", ["-q", "wpa_supplicant"]}
+        {:run, "ifdown", ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]}
       ],
       cleanup_files: ["/tmp/vintage_net/wpa_supplicant/wlan0"]
     }
@@ -1044,7 +1076,13 @@ defmodule VintageNet.Technology.WiFiTest do
       child_specs: [
         {VintageNet.Interface.InternetConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
-         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant", ap_mode: false]}
+         [
+           wpa_supplicant: "wpa_supplicant",
+           ifname: "wlan0",
+           wpa_supplicant_conf_path: "/tmp/vintage_net/wpa_supplicant.conf.wlan0",
+           control_path: "/tmp/vintage_net/wpa_supplicant",
+           ap_mode: false
+         ]}
       ],
       files: [
         {"/tmp/vintage_net/network_interfaces.wlan0", dhcp_interface("wlan0", "unit_test")},
@@ -1063,14 +1101,10 @@ defmodule VintageNet.Technology.WiFiTest do
       up_cmds: [
         {:run_ignore_errors, "ifdown",
          ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]},
-        {:run_ignore_errors, "killall", ["-q", "wpa_supplicant"]},
-        {:run, "wpa_supplicant",
-         ["-B", "-i", "wlan0", "-c", "/tmp/vintage_net/wpa_supplicant.conf.wlan0", "-dd"]},
         {:run, "ifup", ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]}
       ],
       down_cmds: [
-        {:run, "ifdown", ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]},
-        {:run, "killall", ["-q", "wpa_supplicant"]}
+        {:run, "ifdown", ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]}
       ],
       cleanup_files: ["/tmp/vintage_net/wpa_supplicant/wlan0"]
     }
@@ -1098,7 +1132,13 @@ defmodule VintageNet.Technology.WiFiTest do
       child_specs: [
         {VintageNet.Interface.InternetConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
-         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant", ap_mode: true]}
+         [
+           wpa_supplicant: "wpa_supplicant",
+           ifname: "wlan0",
+           wpa_supplicant_conf_path: "/tmp/vintage_net/wpa_supplicant.conf.wlan0",
+           control_path: "/tmp/vintage_net/wpa_supplicant",
+           ap_mode: true
+         ]}
       ],
       files: [
         {"/tmp/vintage_net/network_interfaces.wlan0", dhcp_interface("wlan0", "unit_test")},
@@ -1118,14 +1158,10 @@ defmodule VintageNet.Technology.WiFiTest do
       up_cmds: [
         {:run_ignore_errors, "ifdown",
          ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]},
-        {:run_ignore_errors, "killall", ["-q", "wpa_supplicant"]},
-        {:run, "wpa_supplicant",
-         ["-B", "-i", "wlan0", "-c", "/tmp/vintage_net/wpa_supplicant.conf.wlan0", "-dd"]},
         {:run, "ifup", ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]}
       ],
       down_cmds: [
-        {:run, "ifdown", ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]},
-        {:run, "killall", ["-q", "wpa_supplicant"]}
+        {:run, "ifdown", ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]}
       ],
       cleanup_files: [
         "/tmp/vintage_net/wpa_supplicant/p2p-dev-wlan0",
@@ -1174,7 +1210,13 @@ defmodule VintageNet.Technology.WiFiTest do
       child_specs: [
         {VintageNet.Interface.InternetConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
-         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant", ap_mode: false]}
+         [
+           wpa_supplicant: "wpa_supplicant",
+           ifname: "wlan0",
+           wpa_supplicant_conf_path: "/tmp/vintage_net/wpa_supplicant.conf.wlan0",
+           control_path: "/tmp/vintage_net/wpa_supplicant",
+           ap_mode: false
+         ]}
       ],
       files: [
         {"/tmp/vintage_net/network_interfaces.wlan0", dhcp_interface("wlan0", "unit_test")},
@@ -1206,14 +1248,10 @@ defmodule VintageNet.Technology.WiFiTest do
       up_cmds: [
         {:run_ignore_errors, "ifdown",
          ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]},
-        {:run_ignore_errors, "killall", ["-q", "wpa_supplicant"]},
-        {:run, "wpa_supplicant",
-         ["-B", "-i", "wlan0", "-c", "/tmp/vintage_net/wpa_supplicant.conf.wlan0", "-dd"]},
         {:run, "ifup", ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]}
       ],
       down_cmds: [
-        {:run, "ifdown", ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]},
-        {:run, "killall", ["-q", "wpa_supplicant"]}
+        {:run, "ifdown", ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]}
       ],
       cleanup_files: ["/tmp/vintage_net/wpa_supplicant/wlan0"]
     }
@@ -1251,7 +1289,13 @@ defmodule VintageNet.Technology.WiFiTest do
       child_specs: [
         {VintageNet.Interface.InternetConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
-         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant", ap_mode: false]}
+         [
+           wpa_supplicant: "wpa_supplicant",
+           ifname: "wlan0",
+           wpa_supplicant_conf_path: "/tmp/vintage_net/wpa_supplicant.conf.wlan0",
+           control_path: "/tmp/vintage_net/wpa_supplicant",
+           ap_mode: false
+         ]}
       ],
       files: [
         {"/tmp/vintage_net/network_interfaces.wlan0",
@@ -1283,14 +1327,10 @@ defmodule VintageNet.Technology.WiFiTest do
       up_cmds: [
         {:run_ignore_errors, "ifdown",
          ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]},
-        {:run_ignore_errors, "killall", ["-q", "wpa_supplicant"]},
-        {:run, "wpa_supplicant",
-         ["-B", "-i", "wlan0", "-c", "/tmp/vintage_net/wpa_supplicant.conf.wlan0", "-dd"]},
         {:run, "ifup", ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]}
       ],
       down_cmds: [
-        {:run, "ifdown", ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]},
-        {:run, "killall", ["-q", "wpa_supplicant"]}
+        {:run, "ifdown", ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]}
       ],
       cleanup_files: ["/tmp/vintage_net/wpa_supplicant/wlan0"]
     }
@@ -1329,7 +1369,13 @@ defmodule VintageNet.Technology.WiFiTest do
       child_specs: [
         {VintageNet.Interface.LANConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
-         [ifname: "wlan0", control_path: "/tmp/vintage_net/wpa_supplicant", ap_mode: true]}
+         [
+           wpa_supplicant: "wpa_supplicant",
+           ifname: "wlan0",
+           wpa_supplicant_conf_path: "/tmp/vintage_net/wpa_supplicant.conf.wlan0",
+           control_path: "/tmp/vintage_net/wpa_supplicant",
+           ap_mode: true
+         ]}
       ],
       files: [
         {"/tmp/vintage_net/network_interfaces.wlan0",
@@ -1369,15 +1415,11 @@ defmodule VintageNet.Technology.WiFiTest do
       up_cmds: [
         {:run_ignore_errors, "ifdown",
          ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]},
-        {:run_ignore_errors, "killall", ["-q", "wpa_supplicant"]},
-        {:run, "wpa_supplicant",
-         ["-B", "-i", "wlan0", "-c", "/tmp/vintage_net/wpa_supplicant.conf.wlan0", "-dd"]},
         {:run, "ifup", ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]},
         {:run, "udhcpd", ["/tmp/vintage_net/udhcpd.conf.wlan0"]}
       ],
       down_cmds: [
         {:run, "ifdown", ["-i", "/tmp/vintage_net/network_interfaces.wlan0", "wlan0"]},
-        {:run, "killall", ["-q", "wpa_supplicant"]},
         {:run, "killall", ["-q", "udhcpd"]}
       ],
       cleanup_files: [

--- a/test/vintage_net/wifi/wpa_supplicant_test.exs
+++ b/test/vintage_net/wifi/wpa_supplicant_test.exs
@@ -26,7 +26,13 @@ defmodule VintageNet.WiFi.WPASupplicantTest do
     MockWPASupplicant.set_responses(context.mock, %{"ATTACH" => ["OK\n"]})
 
     _ =
-      start_supervised!({WPASupplicant, ifname: "test_wlan0", control_path: context.socket_path})
+      start_supervised!(
+        {WPASupplicant,
+         wpa_supplicant: "",
+         wpa_supplicant_conf_path: "/dev/null",
+         ifname: "test_wlan0",
+         control_path: context.socket_path}
+      )
 
     Process.sleep(100)
 
@@ -40,7 +46,11 @@ defmodule VintageNet.WiFi.WPASupplicantTest do
     _ =
       start_supervised!(
         {WPASupplicant,
-         ifname: "test_wlan0", control_path: context.socket_path, keep_alive_interval: 10}
+         wpa_supplicant: "",
+         wpa_supplicant_conf_path: "/dev/null",
+         ifname: "test_wlan0",
+         control_path: context.socket_path,
+         keep_alive_interval: 10}
       )
 
     Process.sleep(100)
@@ -67,7 +77,13 @@ defmodule VintageNet.WiFi.WPASupplicantTest do
     })
 
     _supplicant =
-      start_supervised!({WPASupplicant, ifname: "test_wlan0", control_path: context.socket_path})
+      start_supervised!(
+        {WPASupplicant,
+         wpa_supplicant: "",
+         wpa_supplicant_conf_path: "/dev/null",
+         ifname: "test_wlan0",
+         control_path: context.socket_path}
+      )
 
     ap_property = ["interface", "test_wlan0", "wifi", "access_points"]
     VintageNet.PropertyTable.clear(VintageNet, ap_property)
@@ -103,7 +119,14 @@ defmodule VintageNet.WiFi.WPASupplicantTest do
     VintageNet.subscribe(clients_property)
 
     _supplicant =
-      start_supervised!({WPASupplicant, ifname: "test_wlan0", control_path: context.socket_path})
+      start_supervised!(
+        {WPASupplicant,
+         wpa_supplicant: "",
+         wpa_supplicant_conf_path: "/dev/null",
+         ifname: "test_wlan0",
+         control_path: context.socket_path,
+         ap_mode: true}
+      )
 
     # This serves two purposes:
     #  1. tests that the client property is initialized
@@ -129,7 +152,13 @@ defmodule VintageNet.WiFi.WPASupplicantTest do
     })
 
     _supplicant =
-      start_supervised!({WPASupplicant, ifname: "test_wlan0", control_path: context.socket_path})
+      start_supervised!(
+        {WPASupplicant,
+         wpa_supplicant: "",
+         wpa_supplicant_conf_path: "/dev/null",
+         ifname: "test_wlan0",
+         control_path: context.socket_path}
+      )
 
     assert {:error, "FAIL-BUSY"} == WPASupplicant.scan("test_wlan0")
   end
@@ -149,7 +178,13 @@ defmodule VintageNet.WiFi.WPASupplicantTest do
     })
 
     _supplicant =
-      start_supervised!({WPASupplicant, ifname: "test_wlan0", control_path: context.socket_path})
+      start_supervised!(
+        {WPASupplicant,
+         wpa_supplicant: "",
+         wpa_supplicant_conf_path: "/dev/null",
+         ifname: "test_wlan0",
+         control_path: context.socket_path}
+      )
 
     ap_property = ["interface", "test_wlan0", "wifi", "access_points"]
     VintageNet.PropertyTable.clear(VintageNet, ap_property)
@@ -185,7 +220,13 @@ defmodule VintageNet.WiFi.WPASupplicantTest do
     })
 
     _supplicant =
-      start_supervised!({WPASupplicant, ifname: "test_wlan0", control_path: context.socket_path})
+      start_supervised!(
+        {WPASupplicant,
+         wpa_supplicant: "",
+         wpa_supplicant_conf_path: "/dev/null",
+         ifname: "test_wlan0",
+         control_path: context.socket_path}
+      )
 
     ap_property = ["interface", "test_wlan0", "wifi", "access_points"]
     VintageNet.PropertyTable.clear(VintageNet, ap_property)


### PR DESCRIPTION
There's a forced ordering between the C wpa_supplicant and the Elixir
WpaSupplicant. This has a big benefit in grouping their crashes together
and in the ability to remove old control files. The latter was causing
ATTACH timeouts and WpaSupplicant use that would fail after 5 seconds
(the default timeout).

Fixes #116