### PR TITLE
Raise on type errors and missing fields in configs

### DIFF
--- a/lib/vintage_net/technology.ex
+++ b/lib/vintage_net/technology.ex
@@ -11,16 +11,22 @@ defmodule VintageNet.Technology do
   @doc """
   Normalize a configuration
 
-  Technologies can use this to update provided configurations so that same configurations that could
-  be specified in multiple ways have a single representation.
+  Technologies use this to update input configurations to a canonical
+  representation. This includes things like inserting default fields, converting
+  IP addresses passed in as strings to tuples, and deriving parameters so
+  that they need not be derived again in the future.
+
+  Configuration errors raise exceptions.
   """
-  @callback normalize(config :: map()) :: {:ok, map()} | {:error, any()}
+  @callback normalize(config :: map()) :: map()
 
   @doc """
   Convert a technology-specific configuration to one for VintageNet
+
+  Configuration errors raise exceptions.
   """
   @callback to_raw_config(VintageNet.ifname(), config :: map(), opts :: keyword()) ::
-              {:ok, RawConfig.t()} | {:error, any()}
+              RawConfig.t()
 
   @doc """
   Handle an ioctl that has been requested on the network interface

--- a/lib/vintage_net/technology/ethernet.ex
+++ b/lib/vintage_net/technology/ethernet.ex
@@ -5,39 +5,36 @@ defmodule VintageNet.Technology.Ethernet do
   alias VintageNet.IP.ConfigToInterfaces
 
   @impl true
-  def normalize(%{type: __MODULE__} = config), do: {:ok, config}
+  def normalize(%{type: __MODULE__} = config), do: config
 
   @impl true
   def to_raw_config(ifname, %{type: __MODULE__} = config, opts) do
+    normalized_config = normalize(config)
+
     ifup = Keyword.fetch!(opts, :bin_ifup)
     ifdown = Keyword.fetch!(opts, :bin_ifdown)
     tmpdir = Keyword.fetch!(opts, :tmpdir)
 
     network_interfaces_path = Path.join(tmpdir, "network_interfaces.#{ifname}")
 
-    {:ok,
-     %RawConfig{
-       ifname: ifname,
-       type: __MODULE__,
-       source_config: config,
-       files: [
-         {network_interfaces_path,
-          ConfigToInterfaces.config_to_interfaces_contents(ifname, config)}
-       ],
-       child_specs: [{VintageNet.Interface.InternetConnectivityChecker, ifname}],
-       # ifup hangs forever until Ethernet is plugged in
-       up_cmd_millis: 60_000,
-       up_cmds: [
-         {:run_ignore_errors, ifdown, ["-i", network_interfaces_path, ifname]},
-         {:run, ifup, ["-i", network_interfaces_path, ifname]}
-       ],
-       down_cmd_millis: 5_000,
-       down_cmds: [{:run, ifdown, ["-i", network_interfaces_path, ifname]}]
-     }}
-  end
-
-  def to_raw_config(_ifname, _config, _opts) do
-    {:error, :bad_configuration}
+    %RawConfig{
+      ifname: ifname,
+      type: __MODULE__,
+      source_config: normalized_config,
+      files: [
+        {network_interfaces_path,
+         ConfigToInterfaces.config_to_interfaces_contents(ifname, config)}
+      ],
+      child_specs: [{VintageNet.Interface.InternetConnectivityChecker, ifname}],
+      # ifup hangs forever until Ethernet is plugged in
+      up_cmd_millis: 60_000,
+      up_cmds: [
+        {:run_ignore_errors, ifdown, ["-i", network_interfaces_path, ifname]},
+        {:run, ifup, ["-i", network_interfaces_path, ifname]}
+      ],
+      down_cmd_millis: 5_000,
+      down_cmds: [{:run, ifdown, ["-i", network_interfaces_path, ifname]}]
+    }
   end
 
   @impl true

--- a/lib/vintage_net/technology/mobile.ex
+++ b/lib/vintage_net/technology/mobile.ex
@@ -4,7 +4,7 @@ defmodule VintageNet.Technology.Mobile do
   alias VintageNet.Interface.RawConfig
 
   @impl true
-  def normalize(%{type: __MODULE__} = config), do: {:ok, config}
+  def normalize(%{type: __MODULE__} = config), do: config
 
   @impl true
   def to_raw_config(ifname, %{type: __MODULE__, pppd: pppd_config} = config, opts) do
@@ -24,15 +24,14 @@ defmodule VintageNet.Technology.Mobile do
       {:run, killall, ["-q", "pppd"]}
     ]
 
-    {:ok,
-     %RawConfig{
-       ifname: ifname,
-       type: __MODULE__,
-       source_config: config,
-       files: files,
-       up_cmds: up_cmds,
-       down_cmds: down_cmds
-     }}
+    %RawConfig{
+      ifname: ifname,
+      type: __MODULE__,
+      source_config: config,
+      files: files,
+      up_cmds: up_cmds,
+      down_cmds: down_cmds
+    }
   end
 
   def to_raw_config(_ifname, _config, _opts) do

--- a/lib/vintage_net/technology/null.ex
+++ b/lib/vintage_net/technology/null.ex
@@ -10,17 +10,16 @@ defmodule VintageNet.Technology.Null do
   """
 
   @impl true
-  def normalize(_config), do: {:ok, @null_config}
+  def normalize(_config), do: @null_config
 
   @impl true
   def to_raw_config(ifname, _config \\ %{}, _opts \\ []) do
-    {:ok,
-     %RawConfig{
-       ifname: ifname,
-       type: __MODULE__,
-       source_config: @null_config,
-       require_interface: false
-     }}
+    %RawConfig{
+      ifname: ifname,
+      type: __MODULE__,
+      source_config: @null_config,
+      require_interface: false
+    }
   end
 
   @impl true

--- a/test/support/test_technology.ex
+++ b/test/support/test_technology.ex
@@ -8,16 +8,15 @@ defmodule VintageNetTest.TestTechnology do
   """
 
   @impl true
-  def normalize(config), do: {:ok, config}
+  def normalize(config), do: config
 
   @impl true
   def to_raw_config(ifname, _config \\ %{}, _opts \\ []) do
-    {:ok,
-     %RawConfig{
-       ifname: ifname,
-       type: __MODULE__,
-       source_config: %{type: __MODULE__}
-     }}
+    %RawConfig{
+      ifname: ifname,
+      type: __MODULE__,
+      source_config: %{type: __MODULE__}
+    }
   end
 
   @impl true

--- a/test/vintage_net/interface_test.exs
+++ b/test/vintage_net/interface_test.exs
@@ -31,7 +31,7 @@ defmodule VintageNet.InterfaceTest do
 
   test "starting null interface", context do
     in_tmp(context.test, fn ->
-      {:ok, raw_config} = VintageNet.Technology.Null.to_raw_config(@ifname)
+      raw_config = VintageNet.Technology.Null.to_raw_config(@ifname)
       start_and_configure(raw_config)
 
       refute @ifname in VintageNet.configured_interfaces()
@@ -57,7 +57,7 @@ defmodule VintageNet.InterfaceTest do
 
   test "getting the configuration", context do
     in_tmp(context.test, fn ->
-      {:ok, raw_config} = VintageNet.Technology.Null.to_raw_config(@ifname)
+      raw_config = VintageNet.Technology.Null.to_raw_config(@ifname)
       start_and_configure(raw_config)
 
       assert %{type: VintageNet.Technology.Null} == VintageNet.get_configuration(@ifname)

--- a/test/vintage_net/technology/ethernet_test.exs
+++ b/test/vintage_net/technology/ethernet_test.exs
@@ -26,7 +26,7 @@ defmodule VintageNet.Technology.EthernetTest do
       ]
     }
 
-    assert {:ok, output} == Ethernet.to_raw_config("eth0", input, default_opts())
+    assert output == Ethernet.to_raw_config("eth0", input, default_opts())
   end
 
   test "create a wired ethernet configuration with static IP" do
@@ -66,6 +66,6 @@ defmodule VintageNet.Technology.EthernetTest do
       ]
     }
 
-    assert {:ok, output} == Ethernet.to_raw_config("eth0", input, default_opts())
+    assert output == Ethernet.to_raw_config("eth0", input, default_opts())
   end
 end

--- a/test/vintage_net/technology/mobile_test.exs
+++ b/test/vintage_net/technology/mobile_test.exs
@@ -82,6 +82,6 @@ defmodule VintageNet.Technology.MobileTest do
 
     output = ppp_output(input)
 
-    assert {:ok, output} == Mobile.to_raw_config("ppp0", input, default_opts())
+    assert output == Mobile.to_raw_config("ppp0", input, default_opts())
   end
 end

--- a/test/vintage_net/technology/null_test.exs
+++ b/test/vintage_net/technology/null_test.exs
@@ -5,7 +5,7 @@ defmodule VintageNet.Technology.NullTest do
 
   test "normalizing null" do
     # Normalizing anything to Null should be Null
-    assert {:ok, %{type: VintageNet.Technology.Null} == Null.normalize(%{})}
+    assert %{type: VintageNet.Technology.Null} == Null.normalize(%{})
   end
 
   test "converting to raw config" do
@@ -22,6 +22,6 @@ defmodule VintageNet.Technology.NullTest do
       require_interface: false
     }
 
-    assert {:ok, output} == Null.to_raw_config("eth0", input, [])
+    assert output == Null.to_raw_config("eth0", input, [])
   end
 end

--- a/test/vintage_net/technology/wifi_test.exs
+++ b/test/vintage_net/technology/wifi_test.exs
@@ -5,11 +5,6 @@ defmodule VintageNet.Technology.WiFiTest do
 
   import VintageNetTest.Utils
 
-  defp normalize_config(config) do
-    {:ok, normalized} = WiFi.normalize(config)
-    normalized
-  end
-
   test "normalization converts passphrases to psks" do
     input = %{
       type: VintageNet.Technology.WiFi,
@@ -29,7 +24,7 @@ defmodule VintageNet.Technology.WiFiTest do
       }
     }
 
-    assert {:ok, normalized_input} == WiFi.normalize(input)
+    assert normalized_input == WiFi.normalize(input)
   end
 
   test "normalization converts passphrases to psks for multiple networks" do
@@ -73,7 +68,7 @@ defmodule VintageNet.Technology.WiFiTest do
       }
     }
 
-    assert {:ok, normalized_input} == WiFi.normalize(input)
+    assert normalized_input == WiFi.normalize(input)
   end
 
   test "create a WPA2 WiFi configuration" do
@@ -91,7 +86,7 @@ defmodule VintageNet.Technology.WiFiTest do
     output = %RawConfig{
       ifname: "wlan0",
       type: VintageNet.Technology.WiFi,
-      source_config: normalize_config(input),
+      source_config: WiFi.normalize(input),
       child_specs: [
         {VintageNet.Interface.InternetConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
@@ -128,7 +123,7 @@ defmodule VintageNet.Technology.WiFiTest do
       cleanup_files: ["/tmp/vintage_net/wpa_supplicant/wlan0"]
     }
 
-    assert {:ok, output} == WiFi.to_raw_config("wlan0", input, default_opts())
+    assert output == WiFi.to_raw_config("wlan0", input, default_opts())
   end
 
   test "Set regulatory_domain at runtime" do
@@ -144,7 +139,7 @@ defmodule VintageNet.Technology.WiFiTest do
     output = %RawConfig{
       ifname: "wlan0",
       type: VintageNet.Technology.WiFi,
-      source_config: normalize_config(input),
+      source_config: WiFi.normalize(input),
       child_specs: [
         {VintageNet.Interface.InternetConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
@@ -178,7 +173,7 @@ defmodule VintageNet.Technology.WiFiTest do
       cleanup_files: ["/tmp/vintage_net/wpa_supplicant/wlan0"]
     }
 
-    assert {:ok, output} == WiFi.to_raw_config("wlan0", input, default_opts())
+    assert output == WiFi.to_raw_config("wlan0", input, default_opts())
   end
 
   test "create a WPA2 WiFi configuration with passphrase" do
@@ -196,7 +191,7 @@ defmodule VintageNet.Technology.WiFiTest do
     output = %RawConfig{
       ifname: "wlan0",
       type: VintageNet.Technology.WiFi,
-      source_config: normalize_config(input),
+      source_config: WiFi.normalize(input),
       child_specs: [
         {VintageNet.Interface.InternetConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
@@ -233,7 +228,7 @@ defmodule VintageNet.Technology.WiFiTest do
       cleanup_files: ["/tmp/vintage_net/wpa_supplicant/wlan0"]
     }
 
-    assert {:ok, output} == WiFi.to_raw_config("wlan0", input, default_opts())
+    assert output == WiFi.to_raw_config("wlan0", input, default_opts())
   end
 
   test "create a password-less WiFi configuration" do
@@ -250,7 +245,7 @@ defmodule VintageNet.Technology.WiFiTest do
     output = %RawConfig{
       ifname: "wlan0",
       type: VintageNet.Technology.WiFi,
-      source_config: normalize_config(input),
+      source_config: WiFi.normalize(input),
       child_specs: [
         {VintageNet.Interface.InternetConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
@@ -286,7 +281,7 @@ defmodule VintageNet.Technology.WiFiTest do
       cleanup_files: ["/tmp/vintage_net/wpa_supplicant/wlan0"]
     }
 
-    assert {:ok, output} == WiFi.to_raw_config("wlan0", input, default_opts())
+    assert output == WiFi.to_raw_config("wlan0", input, default_opts())
   end
 
   test "create a WEP WiFi configuration" do
@@ -309,7 +304,7 @@ defmodule VintageNet.Technology.WiFiTest do
     output = %RawConfig{
       ifname: "wlan0",
       type: VintageNet.Technology.WiFi,
-      source_config: normalize_config(input),
+      source_config: WiFi.normalize(input),
       child_specs: [
         {VintageNet.Interface.InternetConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
@@ -351,7 +346,7 @@ defmodule VintageNet.Technology.WiFiTest do
       cleanup_files: ["/tmp/vintage_net/wpa_supplicant/wlan0"]
     }
 
-    assert {:ok, output} == WiFi.to_raw_config("wlan0", input, default_opts())
+    assert output == WiFi.to_raw_config("wlan0", input, default_opts())
   end
 
   test "create a hidden WiFi configuration" do
@@ -370,7 +365,7 @@ defmodule VintageNet.Technology.WiFiTest do
     output = %RawConfig{
       ifname: "wlan0",
       type: VintageNet.Technology.WiFi,
-      source_config: normalize_config(input),
+      source_config: WiFi.normalize(input),
       child_specs: [
         {VintageNet.Interface.InternetConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
@@ -408,7 +403,7 @@ defmodule VintageNet.Technology.WiFiTest do
       cleanup_files: ["/tmp/vintage_net/wpa_supplicant/wlan0"]
     }
 
-    assert {:ok, output} == WiFi.to_raw_config("wlan0", input, default_opts())
+    assert output == WiFi.to_raw_config("wlan0", input, default_opts())
   end
 
   test "create a basic EAP network" do
@@ -433,7 +428,7 @@ defmodule VintageNet.Technology.WiFiTest do
     output = %RawConfig{
       ifname: "wlan0",
       type: VintageNet.Technology.WiFi,
-      source_config: normalize_config(input),
+      source_config: WiFi.normalize(input),
       child_specs: [
         {VintageNet.Interface.InternetConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
@@ -477,7 +472,7 @@ defmodule VintageNet.Technology.WiFiTest do
       cleanup_files: ["/tmp/vintage_net/wpa_supplicant/wlan0"]
     }
 
-    assert {:ok, output} == WiFi.to_raw_config("wlan0", input, default_opts())
+    assert output == WiFi.to_raw_config("wlan0", input, default_opts())
   end
 
   test "WPA-Personal(PSK) with TKIP and enforcement for frequent PTK rekeying" do
@@ -499,7 +494,7 @@ defmodule VintageNet.Technology.WiFiTest do
     output = %RawConfig{
       ifname: "wlan0",
       type: VintageNet.Technology.WiFi,
-      source_config: normalize_config(input),
+      source_config: WiFi.normalize(input),
       child_specs: [
         {VintageNet.Interface.InternetConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
@@ -539,7 +534,7 @@ defmodule VintageNet.Technology.WiFiTest do
       cleanup_files: ["/tmp/vintage_net/wpa_supplicant/wlan0"]
     }
 
-    assert {:ok, output} == WiFi.to_raw_config("wlan0", input, default_opts())
+    assert output == WiFi.to_raw_config("wlan0", input, default_opts())
   end
 
   test "Only WPA-EAP is used. Both CCMP and TKIP is accepted" do
@@ -565,7 +560,7 @@ defmodule VintageNet.Technology.WiFiTest do
     output = %RawConfig{
       ifname: "wlan0",
       type: VintageNet.Technology.WiFi,
-      source_config: normalize_config(input),
+      source_config: WiFi.normalize(input),
       child_specs: [
         {VintageNet.Interface.InternetConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
@@ -609,7 +604,7 @@ defmodule VintageNet.Technology.WiFiTest do
       cleanup_files: ["/tmp/vintage_net/wpa_supplicant/wlan0"]
     }
 
-    assert {:ok, output} == WiFi.to_raw_config("wlan0", input, default_opts())
+    assert output == WiFi.to_raw_config("wlan0", input, default_opts())
   end
 
   test "EAP-PEAP/MSCHAPv2 configuration for RADIUS servers that use the new peaplabel" do
@@ -633,7 +628,7 @@ defmodule VintageNet.Technology.WiFiTest do
     output = %RawConfig{
       ifname: "wlan0",
       type: VintageNet.Technology.WiFi,
-      source_config: normalize_config(input),
+      source_config: WiFi.normalize(input),
       child_specs: [
         {VintageNet.Interface.InternetConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
@@ -676,7 +671,7 @@ defmodule VintageNet.Technology.WiFiTest do
       cleanup_files: ["/tmp/vintage_net/wpa_supplicant/wlan0"]
     }
 
-    assert {:ok, output} == WiFi.to_raw_config("wlan0", input, default_opts())
+    assert output == WiFi.to_raw_config("wlan0", input, default_opts())
   end
 
   test "EAP-TTLS/EAP-MD5-Challenge configuration with anonymous identity" do
@@ -699,7 +694,7 @@ defmodule VintageNet.Technology.WiFiTest do
     output = %RawConfig{
       ifname: "wlan0",
       type: VintageNet.Technology.WiFi,
-      source_config: normalize_config(input),
+      source_config: WiFi.normalize(input),
       child_specs: [
         {VintageNet.Interface.InternetConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
@@ -741,7 +736,7 @@ defmodule VintageNet.Technology.WiFiTest do
       cleanup_files: ["/tmp/vintage_net/wpa_supplicant/wlan0"]
     }
 
-    assert {:ok, output} == WiFi.to_raw_config("wlan0", input, default_opts())
+    assert output == WiFi.to_raw_config("wlan0", input, default_opts())
   end
 
   test "WPA-EAP, EAP-TTLS with different CA certificate used for outer and inner authentication" do
@@ -767,7 +762,7 @@ defmodule VintageNet.Technology.WiFiTest do
     output = %RawConfig{
       ifname: "wlan0",
       type: VintageNet.Technology.WiFi,
-      source_config: normalize_config(input),
+      source_config: WiFi.normalize(input),
       child_specs: [
         {VintageNet.Interface.InternetConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
@@ -812,7 +807,7 @@ defmodule VintageNet.Technology.WiFiTest do
       cleanup_files: ["/tmp/vintage_net/wpa_supplicant/wlan0"]
     }
 
-    assert {:ok, output} == WiFi.to_raw_config("wlan0", input, default_opts())
+    assert output == WiFi.to_raw_config("wlan0", input, default_opts())
   end
 
   test "EAP-SIM with a GSM SIM or USIM" do
@@ -832,7 +827,7 @@ defmodule VintageNet.Technology.WiFiTest do
     output = %RawConfig{
       ifname: "wlan0",
       type: VintageNet.Technology.WiFi,
-      source_config: normalize_config(input),
+      source_config: WiFi.normalize(input),
       child_specs: [
         {VintageNet.Interface.InternetConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
@@ -871,7 +866,7 @@ defmodule VintageNet.Technology.WiFiTest do
       cleanup_files: ["/tmp/vintage_net/wpa_supplicant/wlan0"]
     }
 
-    assert {:ok, output} == WiFi.to_raw_config("wlan0", input, default_opts())
+    assert output == WiFi.to_raw_config("wlan0", input, default_opts())
   end
 
   test "EAP PSK" do
@@ -892,7 +887,7 @@ defmodule VintageNet.Technology.WiFiTest do
     output = %RawConfig{
       ifname: "wlan0",
       type: VintageNet.Technology.WiFi,
-      source_config: normalize_config(input),
+      source_config: WiFi.normalize(input),
       child_specs: [
         {VintageNet.Interface.InternetConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
@@ -932,7 +927,7 @@ defmodule VintageNet.Technology.WiFiTest do
       cleanup_files: ["/tmp/vintage_net/wpa_supplicant/wlan0"]
     }
 
-    assert {:ok, output} == WiFi.to_raw_config("wlan0", input, default_opts())
+    assert output == WiFi.to_raw_config("wlan0", input, default_opts())
   end
 
   test "IEEE 802.1X/EAPOL with dynamically generated WEP keys" do
@@ -956,7 +951,7 @@ defmodule VintageNet.Technology.WiFiTest do
     output = %RawConfig{
       ifname: "wlan0",
       type: VintageNet.Technology.WiFi,
-      source_config: normalize_config(input),
+      source_config: WiFi.normalize(input),
       child_specs: [
         {VintageNet.Interface.InternetConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
@@ -999,7 +994,7 @@ defmodule VintageNet.Technology.WiFiTest do
       cleanup_files: ["/tmp/vintage_net/wpa_supplicant/wlan0"]
     }
 
-    assert {:ok, output} == WiFi.to_raw_config("wlan0", input, default_opts())
+    assert output == WiFi.to_raw_config("wlan0", input, default_opts())
   end
 
   test "configuration blacklisting two APs" do
@@ -1017,7 +1012,7 @@ defmodule VintageNet.Technology.WiFiTest do
     output = %RawConfig{
       ifname: "wlan0",
       type: VintageNet.Technology.WiFi,
-      source_config: normalize_config(input),
+      source_config: WiFi.normalize(input),
       child_specs: [
         {VintageNet.Interface.InternetConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
@@ -1054,7 +1049,7 @@ defmodule VintageNet.Technology.WiFiTest do
       cleanup_files: ["/tmp/vintage_net/wpa_supplicant/wlan0"]
     }
 
-    assert {:ok, output} == WiFi.to_raw_config("wlan0", input, default_opts())
+    assert output == WiFi.to_raw_config("wlan0", input, default_opts())
   end
 
   test "configuration limiting AP selection to a specific set of APs" do
@@ -1072,7 +1067,7 @@ defmodule VintageNet.Technology.WiFiTest do
     output = %RawConfig{
       ifname: "wlan0",
       type: VintageNet.Technology.WiFi,
-      source_config: normalize_config(input),
+      source_config: WiFi.normalize(input),
       child_specs: [
         {VintageNet.Interface.InternetConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
@@ -1109,7 +1104,7 @@ defmodule VintageNet.Technology.WiFiTest do
       cleanup_files: ["/tmp/vintage_net/wpa_supplicant/wlan0"]
     }
 
-    assert {:ok, output} == WiFi.to_raw_config("wlan0", input, default_opts())
+    assert output == WiFi.to_raw_config("wlan0", input, default_opts())
   end
 
   test "host AP mode" do
@@ -1128,7 +1123,7 @@ defmodule VintageNet.Technology.WiFiTest do
     output = %RawConfig{
       ifname: "wlan0",
       type: VintageNet.Technology.WiFi,
-      source_config: normalize_config(input),
+      source_config: WiFi.normalize(input),
       child_specs: [
         {VintageNet.Interface.InternetConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
@@ -1169,7 +1164,7 @@ defmodule VintageNet.Technology.WiFiTest do
       ]
     }
 
-    assert {:ok, output} == WiFi.to_raw_config("wlan0", input, default_opts())
+    assert output == WiFi.to_raw_config("wlan0", input, default_opts())
   end
 
   test "create a multi-network WiFi configuration" do
@@ -1206,7 +1201,7 @@ defmodule VintageNet.Technology.WiFiTest do
     output = %RawConfig{
       ifname: "wlan0",
       type: VintageNet.Technology.WiFi,
-      source_config: normalize_config(input),
+      source_config: WiFi.normalize(input),
       child_specs: [
         {VintageNet.Interface.InternetConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
@@ -1256,7 +1251,7 @@ defmodule VintageNet.Technology.WiFiTest do
       cleanup_files: ["/tmp/vintage_net/wpa_supplicant/wlan0"]
     }
 
-    assert {:ok, output} == WiFi.to_raw_config("wlan0", input, default_opts())
+    assert output == WiFi.to_raw_config("wlan0", input, default_opts())
   end
 
   test "creates a static ip config" do
@@ -1285,7 +1280,7 @@ defmodule VintageNet.Technology.WiFiTest do
     output = %RawConfig{
       ifname: "wlan0",
       type: VintageNet.Technology.WiFi,
-      source_config: normalize_config(input),
+      source_config: WiFi.normalize(input),
       child_specs: [
         {VintageNet.Interface.InternetConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
@@ -1335,7 +1330,7 @@ defmodule VintageNet.Technology.WiFiTest do
       cleanup_files: ["/tmp/vintage_net/wpa_supplicant/wlan0"]
     }
 
-    assert {:ok, output} == WiFi.to_raw_config("wlan0", input, default_opts())
+    assert output == WiFi.to_raw_config("wlan0", input, default_opts())
   end
 
   test "create a dhcpd config" do
@@ -1365,7 +1360,7 @@ defmodule VintageNet.Technology.WiFiTest do
     output = %RawConfig{
       ifname: "wlan0",
       type: VintageNet.Technology.WiFi,
-      source_config: normalize_config(input),
+      source_config: WiFi.normalize(input),
       child_specs: [
         {VintageNet.Interface.LANConnectivityChecker, "wlan0"},
         {VintageNet.WiFi.WPASupplicant,
@@ -1428,6 +1423,6 @@ defmodule VintageNet.Technology.WiFiTest do
       ]
     }
 
-    assert {:ok, output} == WiFi.to_raw_config("wlan0", input, default_opts())
+    assert output == WiFi.to_raw_config("wlan0", input, default_opts())
   end
 end

--- a/test/vintage_net_test.exs
+++ b/test/vintage_net_test.exs
@@ -27,7 +27,9 @@ defmodule VintageNetTest do
   end
 
   test "configure fails on bad technologies" do
-    assert {:error, :type_missing} == VintageNet.configure("eth0", %{})
+    assert {:error,
+            "Missing :type field.\n\nSee the help for VintageNet.Technology.Ethernet and VintageNet.Technology.WiFi for\nexample configurations.\n"} ==
+             VintageNet.configure("eth0", %{})
   end
 
   @tag :requires_interfaces_monitor


### PR DESCRIPTION
It's turning out to be quite painful passing around and checking error
tuples everywhere when the only errors that can be caught are type and
missing field ones. These are all programmer errors and are more
typically handled via exceptions anyway.

The main `VintageNet.configure/2` interface still returns error tuples.
This means that users don't need to change any code unless they made
custom technologies.