### PR TITLE
Log wpa_supplicant output

### DIFF
--- a/lib/vintage_net/wifi/wpa_supplicant.ex
+++ b/lib/vintage_net/wifi/wpa_supplicant.ex
@@ -218,6 +218,12 @@ defmodule VintageNet.WiFi.WPASupplicant do
     new_state
   end
 
+  defp handle_notification({:event, "CTRL-EVENT-TERMINATING"}, _state) do
+    # This really shouldn't happen. The only way I know how to cause this
+    # is to send a SIGTERM to the wpa_supplicant.
+    exit(:wpa_supplicant_terminated)
+  end
+
   defp handle_notification(unhandled, state) do
     _ = Logger.info("WPASupplicant ignoring #{inspect(unhandled)}")
     state

--- a/lib/vintage_net/wifi/wpa_supplicant.ex
+++ b/lib/vintage_net/wifi/wpa_supplicant.ex
@@ -81,7 +81,7 @@ defmodule VintageNet.WiFi.WPASupplicant do
         MuonTrap.Daemon.start_link(
           state.wpa_supplicant,
           ["-i", state.ifname, "-c", state.wpa_supplicant_conf_path, "-dd"],
-          VintageNet.Command.add_muon_options([])
+          VintageNet.Command.add_muon_options(stderr_to_stdout: true, log_output: :debug)
         )
       else
         # No wpa_supplicant. The assumption is that someone else started it.

--- a/lib/vintage_net/wifi/wpa_supplicant.ex
+++ b/lib/vintage_net/wifi/wpa_supplicant.ex
@@ -224,6 +224,11 @@ defmodule VintageNet.WiFi.WPASupplicant do
     exit(:wpa_supplicant_terminated)
   end
 
+  defp handle_notification({:info, message}, state) do
+    _ = Logger.info("wpa_supplicant(#{state.ifname}): #{message}")
+    state
+  end
+
   defp handle_notification(unhandled, state) do
     _ = Logger.info("WPASupplicant ignoring #{inspect(unhandled)}")
     state


### PR DESCRIPTION
wpa_supplicant produces a lot of useful output. It will be too much for the normal case after bugs have been worked out. I think the right answer for that time is to make the `-dd` parameter depend on whether a `verbose: true` or other option has been set in the network configuration. Without this commit, the diagnostic output is lost.