### PR TITLE
Remove error about installing gcc+make for C errors

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -15,6 +15,7 @@ defmodule VintageNet.MixProject do
       compilers: [:elixir_make | Mix.compilers()],
       make_targets: ["all"],
       make_clean: ["clean"],
+      make_error_message: "",
       deps: deps(),
       dialyzer: dialyzer(),
       docs: docs(),


### PR DESCRIPTION
The default error message seems to distract people from seeing the real
issue when there's a C compile error.

Specifically, this:

```
<gcc error messages>
** (Mix) Could not compile with "make" (exit status: 2).
You need to have gcc and make installed. If you are using
Ubuntu or any other Debian-based system, install the packages
"build-essential". Also install "erlang-dev" package if not
included in your Erlang/OTP version. If you're on Fedora, run
"dnf group install 'Development Tools'".
```

turns into this:

```
<gcc error messages>
** (Mix) Could not compile with "make" (exit status: 2).
```