### PR TITLE
Save the normalized configuration

### DIFF
--- a/lib/vintage_net.ex
+++ b/lib/vintage_net.ex
@@ -107,7 +107,8 @@ defmodule VintageNet do
     # be bad for it to get an old config. If a GenServer isn't started,
     # configure the running one.
     with {:ok, raw_config} <- Interface.to_raw_config(ifname, config),
-         :ok <- Persistence.call(:save, [ifname, config]),
+         normalized_config = raw_config.source_config,
+         :ok <- Persistence.call(:save, [ifname, normalized_config]),
          {:error, :already_started} <- maybe_start_interface(ifname) do
       Interface.configure(raw_config)
     end


### PR DESCRIPTION
Previously the configuration that was passed in was saved, but it will
be better going forward to save the normalized configuration. This
should reduce the chance that applying a previously successful
configuration does something different on reboot.