### PR TITLE
Add option to turn off configuration persistence

### DIFF
--- a/test/vintage_net_test.exs
+++ b/test/vintage_net_test.exs
@@ -96,6 +96,14 @@ defmodule VintageNetTest do
     refute File.exists?(path)
   end
 
+  test "can turn off configuration persistence" do
+    path = Path.join(Application.get_env(:vintage_net, :persistence_dir), "eth0")
+
+    :ok = VintageNet.configure("eth0", %{type: VintageNet.Technology.Ethernet}, persist: false)
+
+    refute File.exists?(path)
+  end
+
   test "configuration_valid? works" do
     assert VintageNet.configuration_valid?("eth0", %{type: VintageNet.Technology.Ethernet})
     refute VintageNet.configuration_valid?("eth0", %{this_totally_should_not_work: 1})


### PR DESCRIPTION
This allows users to try out a configuration or temporarily override a
configuration. If anything goes wrong and the
device gets rebooted, the old configuration will be applied.

This is needed for network configuration wizards. For example, the
`vintage_net_wizard` switches WiFi adapters to AP mode for
configuration. Consider what happens if configuration mode were entered
accidentally and out of confusion a user reboots the device. With
persistence of AP mode, the device will still not work after a reboot.
However, if the AP mode isn't persisted, then rebooting will fix the
situation.