### PR TITLE
Support default gateways and name servers with static IP setups

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Project](https://nerves-project.org) devices. It has the following features:
 The following network configurations are supported:
 
 * [x] Wired Ethernet, IPv4 DHCP
-* [ ] Wired Ethernet, IPv4 static IP
+* [x] Wired Ethernet, IPv4 static IP
 * [x] WiFi password-less and WEP
 * [x] WPA2 PSK and EAP
 * [ ] USB gadget mode Ethernet, IPv4 DHCP server to supply host IP address
@@ -190,6 +190,26 @@ iex> VintageNet.configure("eth0", %{type: VintageNet.Technology.Ethernet, ipv4: 
 :ok
 ```
 
+Here's a static IP configuration:
+
+```elixir
+iex>   VintageNet.configure("eth0", %{
+    type: VintageNet.Technology.Ethernet,
+    ipv4: %{
+      method: :static,
+      address: "192.168.9.232",
+      prefix_length: 24,
+      gateway: "192.168.9.1",
+      name_servers: ["1.1.1.1"]
+    }
+  })
+:ok
+```
+
+In the above, IP addresses were passed as strings for convenience, but it's also
+possible to pass tuples like `{192, 168, 9, 232}` as is more typical in Elixir
+and Erlang. VintageNet internally works with tuples.
+
 The following fields are supported:
 
 * `:method` - Set to `:dhcp`, `:static`, or `:disabled`. If `:static`, then at
@@ -200,10 +220,12 @@ The following fields are supported:
   (e.g., 24)
 * `:netmask` - either this or `prefix_length` is used to determine the subnet.
 * `:gateway` - the default gateway for this interface (optional)
+* `:name_servers` - a list of name servers for static configurations (optional)
+* `:domain` - a search domain for DNS
 
-Wired Ethernet connections are monitored for Internet connectivity. When
-internet-connected, they are preferred over all other network technologies even
-when the others provide default gateways.
+Wired Ethernet connections are monitored for Internet connectivity if a default
+gateway is available. When internet-connected, they are preferred over all other
+network technologies even when the others provide default gateways.
 
 ### WiFi
 

--- a/lib/vintage_net/interface/command_runner.ex
+++ b/lib/vintage_net/interface/command_runner.ex
@@ -65,14 +65,17 @@ defmodule VintageNet.Interface.CommandRunner do
   end
 
   @doc """
-  Run an arbitrary function
+  Call a function
 
-  In general, try to avoid using this. VintageNet's unit test strategy is
-  to verify configurations rather than verify the execution of the configurations.
-  Functions can't be checked that they were created correctly.
+  In general, prefer the `module, function_name, args` form since it's easier to
+  check in unit tests.
 
   Functions must return `:ok` or `{:error, reason}`.
   """
+  def run({:fun, module, function_name, args}) do
+    apply(module, function_name, args)
+  end
+
   def run({:fun, fun}) do
     fun.()
   end

--- a/lib/vintage_net/interface/raw_config.ex
+++ b/lib/vintage_net/interface/raw_config.ex
@@ -23,8 +23,15 @@ defmodule VintageNet.Interface.RawConfig do
 
   """
 
-  # Should this just be a function??? The down side is that it's less testable since functions are opaque.
-  @type command :: {:run | :run_ignore_errors, String.t(), [String.t()]} | {:fun, function()}
+  @typedoc """
+  A command to run for RawConfig.up_cmds or RawConfig.down_cmds
+  """
+  @type command ::
+          {:run, String.t(), [String.t()]}
+          | {:run_ignore_errors, String.t(), [String.t()]}
+          | {:fun, (() -> :ok | {:error, any()})}
+          | {:fun, module(), atom(), list()}
+
   @type file_contents :: {Path.t(), String.t()}
 
   @enforce_keys [:ifname, :type, :source_config]

--- a/lib/vintage_net/name_resolver.ex
+++ b/lib/vintage_net/name_resolver.ex
@@ -38,7 +38,7 @@ defmodule VintageNet.NameResolver do
 
   This replaces any entries in the `/etc/resolv.conf` for this interface.
   """
-  @spec setup(String.t(), String.t(), [VintageNet.any_ip_address()]) :: :ok
+  @spec setup(String.t(), String.t() | nil, [VintageNet.any_ip_address()]) :: :ok
   def setup(ifname, domain, name_servers) do
     GenServer.call(__MODULE__, {:setup, ifname, domain, name_servers})
   end
@@ -96,7 +96,8 @@ defmodule VintageNet.NameResolver do
     {:reply, :ok, state}
   end
 
-  defp domain_text({_ifname, %{domain: domain}}) when domain != "", do: ["search ", domain, "\n"]
+  defp domain_text({_ifname, %{domain: domain}}) when is_binary(domain) and domain != "",
+    do: ["search ", domain, "\n"]
 
   defp domain_text(_), do: []
 

--- a/test/vintage_net/ip/ipv4_config_test.exs
+++ b/test/vintage_net/ip/ipv4_config_test.exs
@@ -1,4 +1,232 @@
 defmodule VintageNet.IP.IPv4ConfigTest do
   use ExUnit.Case
-  # alias VintageNet.IP.IPv4Config
+  import VintageNetTest.Utils
+
+  alias VintageNet.IP.IPv4Config
+
+  test "raises if no method" do
+    assert_raise ArgumentError, fn -> IPv4Config.normalize(%{ipv4: %{}}) end
+  end
+
+  test "ipv4 disabled default" do
+    default_config = %{ipv4: %{method: :disabled}}
+
+    assert default_config == IPv4Config.normalize(%{ipv4: %{method: :disabled}})
+  end
+
+  test "ipv4 dhcp default" do
+    default_config = %{ipv4: %{method: :dhcp}}
+
+    assert default_config == IPv4Config.normalize(%{ipv4: %{method: :dhcp}})
+  end
+
+  test "ipv4 static default" do
+    default_config = %{
+      ipv4: %{
+        method: :static,
+        address: {192, 168, 1, 1},
+        prefix_length: 24
+      }
+    }
+
+    assert default_config ==
+             IPv4Config.normalize(%{
+               ipv4: %{method: :static, address: "192.168.1.1", netmask: "255.255.255.0"}
+             })
+  end
+
+  test "ipv4 normalizes static" do
+    config = %{
+      ipv4: %{
+        method: :static,
+        address: "192.168.1.2",
+        prefix_length: 24,
+        gateway: "192.168.1.1",
+        name_servers: ["1.1.1.1", {8, 8, 8, 8}],
+        domain: "example.com"
+      }
+    }
+
+    normalized_config = %{
+      ipv4: %{
+        method: :static,
+        address: {192, 168, 1, 2},
+        prefix_length: 24,
+        gateway: {192, 168, 1, 1},
+        name_servers: [{1, 1, 1, 1}, {8, 8, 8, 8}],
+        domain: "example.com"
+      }
+    }
+
+    assert normalized_config == IPv4Config.normalize(config)
+  end
+
+  test "ipv4 dhcp configs" do
+    input =
+      %{
+        hostname: "unit_test",
+        ipv4: %{
+          method: :dhcp
+        }
+      }
+      |> IPv4Config.normalize()
+
+    initial_raw_config = %VintageNet.Interface.RawConfig{
+      ifname: "eth0",
+      source_config: input,
+      type: UnitTest
+    }
+
+    expected = %VintageNet.Interface.RawConfig{
+      type: UnitTest,
+      ifname: "eth0",
+      source_config: input,
+      child_specs: [
+        udhcpc_child_spec("eth0", "unit_test"),
+        {VintageNet.Interface.InternetConnectivityChecker, "eth0"}
+      ],
+      down_cmds: [
+        {:run_ignore_errors, "ip", ["addr", "flush", "dev", "eth0", "label", "eth0"]},
+        {:run, "ip", ["link", "set", "eth0", "down"]}
+      ],
+      up_cmds: [{:run, "ip", ["link", "set", "eth0", "up"]}]
+    }
+
+    assert expected == IPv4Config.add_config(initial_raw_config, input, default_opts())
+  end
+
+  test "ipv4 static config with a default gateway" do
+    input =
+      %{
+        hostname: "unit_test",
+        ipv4: %{
+          method: :static,
+          address: {192, 168, 1, 2},
+          prefix_length: 24,
+          gateway: {192, 168, 1, 1},
+          name_servers: [{1, 1, 1, 1}, {8, 8, 8, 8}],
+          domain: "example.com"
+        }
+      }
+      |> IPv4Config.normalize()
+
+    initial_raw_config = %VintageNet.Interface.RawConfig{
+      ifname: "eth0",
+      source_config: input,
+      type: UnitTest
+    }
+
+    expected = %VintageNet.Interface.RawConfig{
+      type: UnitTest,
+      ifname: "eth0",
+      source_config: input,
+      child_specs: [
+        {VintageNet.Interface.InternetConnectivityChecker, "eth0"}
+      ],
+      down_cmds: [
+        {:fun, VintageNet.RouteManager, :clear_route, ["eth0"]},
+        {:fun, VintageNet.NameResolver, :clear, ["eth0"]},
+        {:run_ignore_errors, "ip", ["addr", "flush", "dev", "eth0", "label", "eth0"]},
+        {:run, "ip", ["link", "set", "eth0", "down"]}
+      ],
+      up_cmds: [
+        {:run_ignore_errors, "ip", ["addr", "flush", "dev", "eth0", "label", "eth0"]},
+        {:run, "ip", ["addr", "add", "192.168.1.2/24", "dev", "eth0", "label", "eth0"]},
+        {:run, "ip", ["link", "set", "eth0", "up"]},
+        {:fun, VintageNet.RouteManager, :set_route,
+         ["eth0", [{{192, 168, 1, 2}, 24}], {192, 168, 1, 1}, :lan]},
+        {:fun, VintageNet.NameResolver, :setup,
+         ["eth0", "example.com", [{1, 1, 1, 1}, {8, 8, 8, 8}]]}
+      ]
+    }
+
+    assert expected == IPv4Config.add_config(initial_raw_config, input, default_opts())
+  end
+
+  test "ipv4 static config without a default gateway" do
+    input =
+      %{
+        hostname: "unit_test",
+        ipv4: %{
+          method: :static,
+          address: {192, 168, 1, 2},
+          prefix_length: 24
+        }
+      }
+      |> IPv4Config.normalize()
+
+    initial_raw_config = %VintageNet.Interface.RawConfig{
+      ifname: "eth0",
+      source_config: input,
+      type: UnitTest
+    }
+
+    expected = %VintageNet.Interface.RawConfig{
+      type: UnitTest,
+      ifname: "eth0",
+      source_config: input,
+      child_specs: [
+        {VintageNet.Interface.LANConnectivityChecker, "eth0"}
+      ],
+      down_cmds: [
+        {:fun, VintageNet.RouteManager, :clear_route, ["eth0"]},
+        {:fun, VintageNet.NameResolver, :clear, ["eth0"]},
+        {:run_ignore_errors, "ip", ["addr", "flush", "dev", "eth0", "label", "eth0"]},
+        {:run, "ip", ["link", "set", "eth0", "down"]}
+      ],
+      up_cmds: [
+        {:run_ignore_errors, "ip", ["addr", "flush", "dev", "eth0", "label", "eth0"]},
+        {:run, "ip", ["addr", "add", "192.168.1.2/24", "dev", "eth0", "label", "eth0"]},
+        {:run, "ip", ["link", "set", "eth0", "up"]},
+        {:fun, VintageNet.RouteManager, :clear_route, ["eth0"]},
+        {:fun, VintageNet.NameResolver, :clear, ["eth0"]}
+      ]
+    }
+
+    assert expected == IPv4Config.add_config(initial_raw_config, input, default_opts())
+  end
+
+  test "ipv4 static config with one name server" do
+    input =
+      %{
+        hostname: "unit_test",
+        ipv4: %{
+          method: :static,
+          address: {192, 168, 1, 2},
+          prefix_length: 24,
+          name_servers: "1.2.3.4"
+        }
+      }
+      |> IPv4Config.normalize()
+
+    initial_raw_config = %VintageNet.Interface.RawConfig{
+      ifname: "eth0",
+      source_config: input,
+      type: UnitTest
+    }
+
+    expected = %VintageNet.Interface.RawConfig{
+      type: UnitTest,
+      ifname: "eth0",
+      source_config: input,
+      child_specs: [
+        {VintageNet.Interface.LANConnectivityChecker, "eth0"}
+      ],
+      down_cmds: [
+        {:fun, VintageNet.RouteManager, :clear_route, ["eth0"]},
+        {:fun, VintageNet.NameResolver, :clear, ["eth0"]},
+        {:run_ignore_errors, "ip", ["addr", "flush", "dev", "eth0", "label", "eth0"]},
+        {:run, "ip", ["link", "set", "eth0", "down"]}
+      ],
+      up_cmds: [
+        {:run_ignore_errors, "ip", ["addr", "flush", "dev", "eth0", "label", "eth0"]},
+        {:run, "ip", ["addr", "add", "192.168.1.2/24", "dev", "eth0", "label", "eth0"]},
+        {:run, "ip", ["link", "set", "eth0", "up"]},
+        {:fun, VintageNet.RouteManager, :clear_route, ["eth0"]},
+        {:fun, VintageNet.NameResolver, :setup, ["eth0", nil, [{1, 2, 3, 4}]]}
+      ]
+    }
+
+    assert expected == IPv4Config.add_config(initial_raw_config, input, default_opts())
+  end
 end

--- a/test/vintage_net/name_resolver_test.exs
+++ b/test/vintage_net/name_resolver_test.exs
@@ -105,4 +105,23 @@ defmodule VintageNet.Interface.NameResolverTest do
       NameResolver.stop()
     end)
   end
+
+  test "no search domain", context do
+    in_tmp(context.test, fn ->
+      NameResolver.start_link(resolvconf: @resolvconf_path)
+      NameResolver.setup("eth0", nil, [{1, 1, 1, 1}])
+
+      contents = File.read!(@resolvconf_path)
+
+      assert contents == """
+             nameserver 1.1.1.1
+             """
+
+      NameResolver.clear("eth0")
+      contents = File.read!(@resolvconf_path)
+      assert contents == ""
+
+      NameResolver.stop()
+    end)
+  end
 end

--- a/test/vintage_net/name_resolver_test.exs
+++ b/test/vintage_net/name_resolver_test.exs
@@ -85,4 +85,24 @@ defmodule VintageNet.Interface.NameResolverTest do
       NameResolver.stop()
     end)
   end
+
+  test "tuple IP addresses", context do
+    in_tmp(context.test, fn ->
+      NameResolver.start_link(resolvconf: @resolvconf_path)
+      NameResolver.setup("eth0", "example.com", [{1, 1, 1, 1}])
+
+      contents = File.read!(@resolvconf_path)
+
+      assert contents == """
+             search example.com
+             nameserver 1.1.1.1
+             """
+
+      NameResolver.clear("eth0")
+      contents = File.read!(@resolvconf_path)
+      assert contents == ""
+
+      NameResolver.stop()
+    end)
+  end
 end

--- a/test/vintage_net/technology/ethernet_test.exs
+++ b/test/vintage_net/technology/ethernet_test.exs
@@ -31,30 +31,36 @@ defmodule VintageNet.Technology.EthernetTest do
       ipv4: %{
         method: :static,
         address: "192.168.0.2",
-        netmask: "255.255.255.0",
-        gateway: "192.168.0.1"
+        netmask: "255.255.255.0"
       },
       hostname: "unit_test"
     }
 
-    # Static IP support is not implemented. This is what is currently produced,
-    # but it is incomplete.
     output = %RawConfig{
       type: VintageNet.Technology.Ethernet,
       ifname: "eth0",
       source_config: %{
         hostname: "unit_test",
         type: VintageNet.Technology.Ethernet,
-        ipv4: %{method: :static, address: {192, 168, 0, 2}, prefix_length: 24}
+        ipv4: %{
+          method: :static,
+          address: {192, 168, 0, 2},
+          prefix_length: 24
+        }
       },
       child_specs: [{VintageNet.Interface.LANConnectivityChecker, "eth0"}],
       down_cmds: [
+        {:fun, VintageNet.RouteManager, :clear_route, ["eth0"]},
+        {:fun, VintageNet.NameResolver, :clear, ["eth0"]},
         {:run_ignore_errors, "ip", ["addr", "flush", "dev", "eth0", "label", "eth0"]},
         {:run, "ip", ["link", "set", "eth0", "down"]}
       ],
       up_cmds: [
+        {:run_ignore_errors, "ip", ["addr", "flush", "dev", "eth0", "label", "eth0"]},
         {:run, "ip", ["addr", "add", "192.168.0.2/24", "dev", "eth0", "label", "eth0"]},
-        {:run, "ip", ["link", "set", "eth0", "up"]}
+        {:run, "ip", ["link", "set", "eth0", "up"]},
+        {:fun, VintageNet.RouteManager, :clear_route, ["eth0"]},
+        {:fun, VintageNet.NameResolver, :clear, ["eth0"]}
       ]
     }
 
@@ -82,7 +88,11 @@ defmodule VintageNet.Technology.EthernetTest do
       source_config: %{
         hostname: "unit_test",
         type: VintageNet.Technology.Ethernet,
-        ipv4: %{method: :static, address: {192, 168, 24, 1}, prefix_length: 24},
+        ipv4: %{
+          method: :static,
+          address: {192, 168, 24, 1},
+          prefix_length: 24
+        },
         dhcpd: %{start: {192, 168, 24, 2}, end: {192, 168, 24, 100}}
       },
       child_specs: [
@@ -115,12 +125,17 @@ defmodule VintageNet.Technology.EthernetTest do
          """}
       ],
       down_cmds: [
+        {:fun, VintageNet.RouteManager, :clear_route, ["eth0"]},
+        {:fun, VintageNet.NameResolver, :clear, ["eth0"]},
         {:run_ignore_errors, "ip", ["addr", "flush", "dev", "eth0", "label", "eth0"]},
         {:run, "ip", ["link", "set", "eth0", "down"]}
       ],
       up_cmds: [
+        {:run_ignore_errors, "ip", ["addr", "flush", "dev", "eth0", "label", "eth0"]},
         {:run, "ip", ["addr", "add", "192.168.24.1/24", "dev", "eth0", "label", "eth0"]},
-        {:run, "ip", ["link", "set", "eth0", "up"]}
+        {:run, "ip", ["link", "set", "eth0", "up"]},
+        {:fun, VintageNet.RouteManager, :clear_route, ["eth0"]},
+        {:fun, VintageNet.NameResolver, :clear, ["eth0"]}
       ]
     }
 

--- a/test/vintage_net/technology/gadget_test.exs
+++ b/test/vintage_net/technology/gadget_test.exs
@@ -37,14 +37,19 @@ defmodule VintageNet.Technology.GadgetTest do
         {VintageNet.Interface.LANConnectivityChecker, "usb0"}
       ],
       down_cmds: [
+        {:fun, VintageNet.RouteManager, :clear_route, ["usb0"]},
+        {:fun, VintageNet.NameResolver, :clear, ["usb0"]},
         {:run_ignore_errors, "ip", ["addr", "flush", "dev", "usb0", "label", "usb0"]},
         {:run, "ip", ["link", "set", "usb0", "down"]}
       ],
       files: [],
       up_cmd_millis: 5000,
       up_cmds: [
+        {:run_ignore_errors, "ip", ["addr", "flush", "dev", "usb0", "label", "usb0"]},
         {:run, "ip", ["addr", "add", "172.31.246.65/30", "dev", "usb0", "label", "usb0"]},
-        {:run, "ip", ["link", "set", "usb0", "up"]}
+        {:run, "ip", ["link", "set", "usb0", "up"]},
+        {:fun, VintageNet.RouteManager, :clear_route, ["usb0"]},
+        {:fun, VintageNet.NameResolver, :clear, ["usb0"]}
       ]
     }
 


### PR DESCRIPTION
This makes it possible to use static addressing for real now. I had to refactor the command runner and the name resolver to make the code look nicer. This also adds tests to the IPv4 which had previously been relying on the Ethernet and WiFi tests for coverage.

I did add code to flush existing addresses of network interfaces and redundant calls to clear names and default gateways. I saw one crash condition that could leave an address on an interface. It turned out to be due to a bug in the code, but it felt good to reset state at the beginning just in case something similar were ever to happen in practice.