### PR TITLE
Remove support for specifying mode by number

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,13 +22,6 @@ install_system_deps: &install_system_deps
       apt update
       apt install -y unzip libmnl-dev libnl-genl-3-dev
 
-install_mdl: &install_mdl
-  run:
-    name: Install Markdown Lint
-    command: |
-      apt install -y ruby
-      gem install mdl
-
 defaults: &defaults
   working_directory: ~/repo
 
@@ -44,7 +37,6 @@ jobs:
     steps:
       - checkout
       - <<: *install_system_deps
-      - <<: *install_mdl
       - <<: *install_elixir
       - <<: *install_hex_rebar
       - restore_cache:
@@ -53,7 +45,6 @@ jobs:
       - run: mix deps.get
       - run: MIX_ENV=test mix coveralls.circle
       - run: mix format --check-formatted
-      - run: mdl --style .circleci/md-style.rb *.md
       - run: MIX_ENV=docs mix docs
       - run: mix hex.build
       - run: mix dialyzer --halt-exit-status

--- a/README.md
+++ b/README.md
@@ -252,9 +252,9 @@ The `:wifi` key has the following common fields:
   VintageNet connects to the first available network in the list. In host mode,
   the list should have one entry with SSID and password information.
   * `:mode` -
-    * `:client` (default) - Normal operation. Associate with an AP
-    * `:adhoc` - peer to peer mode (not supported)
-    * `:host` - access point mode
+    * `:infrastructure` (default) - Normal operation. Associate with an AP
+    * `:ap` - access point mode
+    * `:ibss` - peer to peer mode (not supported)
   * `:ssid` - The SSID for the network
   * `:key_mgmt` - WiFi security mode (`:wpa_psk` for WPA2, `:none` for no
     password or WEP)
@@ -341,7 +341,7 @@ iex> VintageNet.configure("wlan0", %{
       wifi: %{
         networks: [
           %{
-            mode: :host,
+            mode: :ap,
             ssid: "test ssid",
             key_mgmt: :none
           }
@@ -449,7 +449,7 @@ Interface wlan0
       type: VintageNet.Technology.WiFi,
       wifi: %{
         key_mgmt: :wpa_psk,
-        mode: :client,
+        mode: :infrastructure,
         psk: "******",
         ssid: "MyLAN"
       }

--- a/lib/vintage_net/technology/wifi.ex
+++ b/lib/vintage_net/technology/wifi.ex
@@ -320,8 +320,6 @@ defmodule VintageNet.Technology.WiFi do
   defp mode_to_string(:infrastructure), do: "0"
   defp mode_to_string(:ibss), do: "1"
   defp mode_to_string(:ap), do: "2"
-  # In case the user supplies data as the integer type
-  defp mode_to_string(mode) when is_integer(mode), do: mode
 
   defp bgscan_to_string(:simple), do: "\"simple\""
   defp bgscan_to_string({:simple, args}), do: "\"simple:#{args}\""
@@ -571,11 +569,10 @@ defmodule VintageNet.Technology.WiFi do
     end)
   end
 
-  defp ap_mode?(%{wifi: %{networks: [%{mode: mode}]}}) when mode in [:ap, 2], do: true
+  defp ap_mode?(%{wifi: %{networks: [%{mode: :ap}]}}), do: true
   defp ap_mode?(_config), do: false
 
-  defp ctrl_interface_paths(ifname, dir, %{wifi: %{networks: [%{mode: mode}]}})
-       when mode in [:ap, 2] do
+  defp ctrl_interface_paths(ifname, dir, %{wifi: %{networks: [%{mode: :ap}]}}) do
     # Some WiFi drivers expose P2P interfaces and those should be cleaned up too.
     [Path.join(dir, "p2p-dev-#{ifname}"), Path.join(dir, ifname)]
   end

--- a/lib/vintage_net/technology/wifi.ex
+++ b/lib/vintage_net/technology/wifi.ex
@@ -314,8 +314,6 @@ defmodule VintageNet.Technology.WiFi do
   defp key_mgmt_to_string(:wpa_psk), do: "WPA-PSK"
   defp key_mgmt_to_string(:wpa_eap), do: "WPA-EAP"
   defp key_mgmt_to_string(:IEEE8021X), do: "IEEE8021X"
-  # This is to allow passing multi mgmts
-  defp key_mgmt_to_string(string) when is_binary(string), do: string
 
   defp mode_to_string(:infrastructure), do: "0"
   defp mode_to_string(:ibss), do: "1"

--- a/test/vintage_net/technology/wifi_test.exs
+++ b/test/vintage_net/technology/wifi_test.exs
@@ -20,7 +20,7 @@ defmodule VintageNet.Technology.WiFiTest do
           %{
             ssid: "guest",
             key_mgmt: :none,
-            mode: :client
+            mode: :infrastructure
           }
         ]
       }
@@ -45,7 +45,7 @@ defmodule VintageNet.Technology.WiFiTest do
           %{
             ssid: "my_ap",
             key_mgmt: :none,
-            mode: :host
+            mode: :ap
           }
         ]
       }
@@ -54,6 +54,37 @@ defmodule VintageNet.Technology.WiFiTest do
     assert capture_log(fn ->
              assert normalized_input == WiFi.normalize(input)
            end) =~ "deprecated"
+  end
+
+  test "normalizes old way of specifying infrastructure mode" do
+    input = %{
+      type: VintageNet.Technology.WiFi,
+      wifi: %{
+        networks: [
+          %{
+            ssid: "guest",
+            key_mgmt: :none,
+            mode: :client
+          }
+        ]
+      }
+    }
+
+    normalized_input = %{
+      type: VintageNet.Technology.WiFi,
+      ipv4: %{method: :dhcp},
+      wifi: %{
+        networks: [
+          %{
+            ssid: "guest",
+            key_mgmt: :none,
+            mode: :infrastructure
+          }
+        ]
+      }
+    }
+
+    assert normalized_input == WiFi.normalize(input)
   end
 
   test "normalizing an empty config works" do
@@ -168,7 +199,7 @@ defmodule VintageNet.Technology.WiFiTest do
             ssid: "IEEE",
             psk: "F42C6FC52DF0EBEF9EBB4B90B38A5F902E83FE1B135A70E23AED762E9710A12E",
             key_mgmt: :wpa_psk,
-            mode: :client
+            mode: :infrastructure
           }
         ]
       }
@@ -206,13 +237,13 @@ defmodule VintageNet.Technology.WiFiTest do
             ssid: "IEEE",
             psk: "F42C6FC52DF0EBEF9EBB4B90B38A5F902E83FE1B135A70E23AED762E9710A12E",
             key_mgmt: :wpa_psk,
-            mode: :client
+            mode: :infrastructure
           },
           %{
             ssid: "IEEE2",
             psk: "B06433395BD30B1455F538904B239D10A51964932A81D1407BAF2BA0767E22E9",
             key_mgmt: :wpa_psk,
-            mode: :client
+            mode: :infrastructure
           }
         ]
       }
@@ -1342,7 +1373,7 @@ defmodule VintageNet.Technology.WiFiTest do
       type: VintageNet.Technology.WiFi,
       wifi: %{
         networks: [
-          %{mode: :host, ssid: "example ap", psk: "very secret passphrase", key_mgmt: :wpa_psk}
+          %{mode: :ap, ssid: "example ap", psk: "very secret passphrase", key_mgmt: :wpa_psk}
         ]
       },
       ipv4: %{method: :disabled},
@@ -1543,7 +1574,7 @@ defmodule VintageNet.Technology.WiFiTest do
       wifi: %{
         networks: [
           %{
-            mode: :host,
+            mode: :ap,
             ssid: "example ap",
             key_mgmt: :none,
             scan_ssid: 1


### PR DESCRIPTION
Once configuration normalization was added, this condition could never
happen.