### PR TITLE
Fix spec for subscribing to and getting properties

### DIFF
--- a/lib/vintage_net.ex
+++ b/lib/vintage_net.ex
@@ -200,7 +200,7 @@ defmodule VintageNet do
   VintageNet.subscribe(["interface", :_, "addresses"])
   ```
   """
-  @spec subscribe(PropertyTable.property()) :: :ok
+  @spec subscribe(PropertyTable.property_with_wildcards()) :: :ok
   def subscribe(name) do
     PropertyTable.subscribe(VintageNet, name)
   end
@@ -208,7 +208,7 @@ defmodule VintageNet do
   @doc """
   Stop subscribing to property change messages
   """
-  @spec unsubscribe(PropertyTable.property()) :: :ok
+  @spec unsubscribe(PropertyTable.property_with_wildcards()) :: :ok
   def unsubscribe(name) do
     PropertyTable.unsubscribe(VintageNet, name)
   end

--- a/test/vintage_net/property_table_test.exs
+++ b/test/vintage_net/property_table_test.exs
@@ -29,6 +29,16 @@ defmodule VintageNet.PropertyTableTest do
     refute_receive {^table, ["a", "b", "d"], _, _, _}
   end
 
+  test "getting invalid properties raises", %{table: table} do
+    # Wildcards aren't allowed
+    assert_raise ArgumentError, fn -> PropertyTable.get(table, [:_, "a"]) end
+    assert_raise ArgumentError, fn -> PropertyTable.get(table, [:_]) end
+
+    # Non-string lists aren't allowed
+    assert_raise ArgumentError, fn -> PropertyTable.get(table, ['nope']) end
+    assert_raise ArgumentError, fn -> PropertyTable.get(table, ["a", 5]) end
+  end
+
   test "sending events", %{table: table} do
     name = ["test"]
     PropertyTable.subscribe(table, name)


### PR DESCRIPTION
This makes it possible to subscribe to properties using wildcards
without getting Dialyzer warnings. It also updates the property
assertion code so incorrect usage is flagged at runtime.