### PR TITLE
Make max interface count part of API

### DIFF
--- a/lib/vintage_net.ex
+++ b/lib/vintage_net.ex
@@ -88,6 +88,20 @@ defmodule VintageNet do
   end
 
   @doc """
+  Return the maximum number of interfaces controlled by VintageNet
+
+  Internal constraints mean that VintageNet can't manage an arbitrary number of
+  interfaces and knowing the max can reduce some processing. The limit is set
+  by the application config. Unless you need over 100 network interfaces,
+  VintageNet's use of the Linux networking API is not likely to be an issue,
+  though.
+  """
+  @spec max_interface_count() :: 1..100
+  def max_interface_count() do
+    Application.get_env(:vintage_net, :max_interface_count)
+  end
+
+  @doc """
   Update the configuration of a network interface
 
   Configurations are validated and normalized before being applied.  This means

--- a/lib/vintage_net/route/calculator.ex
+++ b/lib/vintage_net/route/calculator.ex
@@ -36,6 +36,14 @@ defmodule VintageNet.Route.Calculator do
   end
 
   @doc """
+  Return the table indices used for routing based on source IP.
+  """
+  def rule_table_index_range() do
+    max_index = 100 + VintageNet.max_interface_count() - 1
+    100..max_index
+  end
+
+  @doc """
   Compute a Linux routing table configuration
 
   The entries are ordered so that List.myers_difference/2 can be used to
@@ -148,9 +156,9 @@ defmodule VintageNet.Route.Calculator do
     # matter...
     used = Map.values(table_indices)
 
-    case Enum.find(100..200, fn n -> not Enum.member?(used, n) end) do
+    case Enum.find(rule_table_index_range(), fn n -> not Enum.member?(used, n) end) do
       nil ->
-        raise "VintageNet.Route.Calculator ran out of table indices???"
+        raise "VintageNet.Route.Calculator ran out of table indices. This is probably due to more than `:max_interface_count` in use simultaneously."
 
       picked ->
         picked

--- a/lib/vintage_net/route_manager.ex
+++ b/lib/vintage_net/route_manager.ex
@@ -108,7 +108,7 @@ defmodule VintageNet.RouteManager do
   def init(_args) do
     # Fresh slate
     IPRoute.clear_all_routes()
-    IPRoute.clear_all_rules(100..200)
+    IPRoute.clear_all_rules(Calculator.rule_table_index_range())
 
     state =
       %State{

--- a/mix.exs
+++ b/mix.exs
@@ -31,6 +31,7 @@ defmodule VintageNet.MixProject do
       # Program names are found at application start and converted to absolute.
       env: [
         config: [],
+        max_interface_count: 8,
         tmpdir: "/tmp/vintage_net",
         to_elixir_socket: "comms",
         bin_dnsd: "dnsd",

--- a/test/vintage_net/route/calculator_test.exs
+++ b/test/vintage_net/route/calculator_test.exs
@@ -188,4 +188,8 @@ defmodule VintageNet.Route.CalculatorTest do
               {:default_route, "eth0", {192, 168, 1, 1}, 10, :main}
             ]} == Calculator.compute(state, interfaces, prioritization)
   end
+
+  test "rule table index range is as expected" do
+    assert 100..107 == Calculator.rule_table_index_range()
+  end
 end

--- a/test/vintage_net_test.exs
+++ b/test/vintage_net_test.exs
@@ -146,6 +146,10 @@ defmodule VintageNetTest do
     end)
   end
 
+  test "max interface count works" do
+    assert 8 == VintageNet.max_interface_count()
+  end
+
   defp prefix_paths(opts, prefix) do
     Enum.map(opts, fn kv -> prefix_path(kv, prefix) end)
   end


### PR DESCRIPTION
This unhides an internal limitation of how many interfaces that
VintageNet supports. Linux provides one constraint that's pretty high.
VintageNet's use of the `ip rule` puts a fixable limit of about 150
network interfaces. It is, however, nice to reduce the limit to
something more realistic and small so avoid noise when cleaning up
tables. This sets it to 8 network interfaces per device. That seems
more than sufficient for most Nerves users.