### PR TITLE
Fix non-integer GenServer timeout

### DIFF
--- a/lib/vintage_net/interface/internet_connectivity_checker.ex
+++ b/lib/vintage_net/interface/internet_connectivity_checker.ex
@@ -149,7 +149,7 @@ defmodule VintageNet.Interface.InternetConnectivityChecker do
 
   # If a ping fails, retry, but don't wait as long as when everything is working
   defp next_interval(:internet, _interval, strikes) do
-    max(@min_interval, @max_interval / (strikes + 1))
+    max(@min_interval, div(@max_interval, strikes + 1))
   end
 
   # Back off of checks if they're not working


### PR DESCRIPTION
This fixes the following error report:

```
01:43:02.049 [error] Child
VintageNet.Interface.InternetConnectivityChecker of Supervisor
** (exit) an exception was raised:
    ** (ErlangError) Erlang error: :timeout_value
        (stdlib) gen_server.erl:394: :gen_server.loop/7
        (stdlib) proc_lib.erl:249: :proc_lib.init_p_do_apply/3
Pid: #PID<0.1100.0>
Start Call:
VintageNet.Interface.InternetConnectivityChecker.start_link("eth0")
Restart: :permanent
Shutdown: 5000
Type: :worker
```

The error was caused by a floating point number being used as a timeout
(i.e., the `:timeout_value` error). Switching to `div/2` ensures that
the division result is an integer. (Divide by 0 is not possible since
it's checked already).

Fixes #117