### PR TITLE
Fix missing address update on dhcp restart

### DIFF
--- a/lib/vintage_net/interfaces_monitor/info.ex
+++ b/lib/vintage_net/interfaces_monitor/info.ex
@@ -99,6 +99,18 @@ defmodule VintageNet.InterfacesMonitor.Info do
   end
 
   @doc """
+  Remove all IPv4 addresses
+  """
+  @spec delete_ipv4_addresses(t()) :: t()
+  def delete_ipv4_addresses(info) do
+    new_addresses =
+      info.addresses
+      |> Enum.filter(fn entry -> tuple_size(entry.address) != 4 end)
+
+    %{info | addresses: new_addresses}
+  end
+
+  @doc """
   Clear out all properties exported by this module
   """
   @spec clear_properties(VintageNet.ifname()) :: :ok

--- a/lib/vintage_net/interfaces_monitor/info.ex
+++ b/lib/vintage_net/interfaces_monitor/info.ex
@@ -87,7 +87,7 @@ defmodule VintageNet.InterfacesMonitor.Info do
   end
 
   @doc """
-  Remove and address from the interface info
+  Handle the deladdr report
   """
   @spec deladdr(t(), map()) :: t()
   def deladdr(info, address_report) do

--- a/test/vintage_net/interfaces_monitor/info_test.exs
+++ b/test/vintage_net/interfaces_monitor/info_test.exs
@@ -1,0 +1,113 @@
+defmodule VintageNet.InterfacesMonitor.InfoTest do
+  use ExUnit.Case
+  doctest VintageNet.InterfacesMonitor.Info
+  alias VintageNet.InterfacesMonitor.Info
+
+  test "new interfaces don't have link information or addresses" do
+    info = Info.new("eth0")
+    assert info == %VintageNet.InterfacesMonitor.Info{addresses: [], ifname: "eth0", link: %{}}
+  end
+
+  test "newlink reports replace the link information" do
+    info = Info.new("eth0")
+    before_info = Info.newlink(info, example_link_report("before_mac", true))
+    after_info = Info.newlink(before_info, example_link_report("after_mac", true))
+
+    assert before_info.link == example_link_report("before_mac", true)
+    assert after_info.link == example_link_report("after_mac", true)
+  end
+
+  test "newaddr and deladdr" do
+    info = Info.new("eth0")
+
+    info = Info.newaddr(info, example_ipv4_report(1))
+    assert info.addresses == [example_ipv4_report(1)]
+
+    info = Info.deladdr(info, example_ipv4_report(1))
+    assert info.addresses == []
+  end
+
+  test "multiple addresses" do
+    info =
+      Info.new("eth0")
+      |> Info.newaddr(example_ipv4_report(1))
+      |> Info.newaddr(example_ipv4_report(2))
+      |> Info.newaddr(example_ipv4_report(3))
+      |> Info.newaddr(example_ipv6_report(4))
+      |> Info.newaddr(example_ipv6_report(5))
+      |> Info.deladdr(example_ipv4_report(2))
+
+    assert info.addresses == [
+             example_ipv6_report(5),
+             example_ipv6_report(4),
+             example_ipv4_report(3),
+             example_ipv4_report(1)
+           ]
+  end
+
+  test "removing all ipv4" do
+    info =
+      Info.new("eth0")
+      |> Info.newaddr(example_ipv4_report(1))
+      |> Info.newaddr(example_ipv4_report(2))
+      |> Info.newaddr(example_ipv4_report(3))
+      |> Info.newaddr(example_ipv6_report(4))
+      |> Info.newaddr(example_ipv6_report(5))
+      |> Info.delete_ipv4_addresses()
+
+    assert info.addresses == [
+             example_ipv6_report(5),
+             example_ipv6_report(4)
+           ]
+  end
+
+  defp example_link_report(mac_address, up) do
+    %{
+      broadcast: true,
+      lower_up: true,
+      mac_address: mac_address,
+      mac_broadcast: "ff:ff:ff:ff:ff:ff",
+      mtu: 1500,
+      multicast: true,
+      operstate: :down,
+      running: false,
+      stats: %{
+        collisions: 0,
+        multicast: 0,
+        rx_bytes: 0,
+        rx_dropped: 0,
+        rx_errors: 0,
+        rx_packets: 0,
+        tx_bytes: 0,
+        tx_dropped: 0,
+        tx_errors: 0,
+        tx_packets: 0
+      },
+      type: :ethernet,
+      up: up
+    }
+  end
+
+  defp example_ipv4_report(index) when index > 0 and index < 255 do
+    %{
+      address: {192, 168, 10, index},
+      broadcast: {192, 168, 10, 255},
+      family: :inet,
+      label: "eth0",
+      local: {192, 168, 10, 10},
+      permanent: false,
+      prefixlen: 24,
+      scope: :universe
+    }
+  end
+
+  defp example_ipv6_report(index) when index > 0 and index < 65535 do
+    %{
+      address: {65152, 0, 0, 0, 45461, 64234, 43649, index},
+      family: :inet6,
+      permanent: true,
+      prefixlen: 64,
+      scope: :link
+    }
+  end
+end


### PR DESCRIPTION
If the DHCP client was restarted (for any reason), it first reports that
the network interface should be deconfigured and then reports the new
(likely the same) lease. This works. However, the deconfig/renew ends up
clearing multicast registrations on the IP address being deconfig/renew'd.
This broke mDNS since it was listening on the IP address.

To fix this, code is added to clear out all IPv4 addresses on deconfig.
This propogates the "glitch" in IP network connectivity throughout and as
soon as it could possibly happen. When the IP address comes back via the
renew, `mdns_lite` will register a listener and all will work.

It should be noted that the GenServer crash that caused this bug to happen
has been fixed. One way of reproducing is to back out
bc8073a5d694de3da1cd3169cb1002fc9ea9015f.