### PR TITLE
Fix WiFi config keys

### DIFF
--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -112,7 +112,7 @@ keys.
 ```elixir
 %{
   type: VintageNetWiFi,
-  wifi: %{
+  vintage_net_wifi: %{
     key_mgmt: :wpa_psk,
     ssid: "my_network_ssid",
     psk: "secret_password",
@@ -130,7 +130,7 @@ Protected EAP (PEAP) is a common authentication protocol for enterprise WiFi net
 ```elixir
 %{
   type: VintageNetWiFi,
-  wifi: %{
+  vintage_net_wifi: %{
     networks: [
       %{
         key_mgmt: :wpa_eap,


### PR DESCRIPTION
While testing out these configs, I found that `wifi:` doesn't work as documented here. I'm not sure whether it's supposed to, but `vintage_net_wifi:`, like the `VintageNetWiFi` docs describe, does work.