### PR TITLE
Prefix udhcpc logs with interface

### DIFF
--- a/lib/vintage_net/ip/ipv4_config.ex
+++ b/lib/vintage_net/ip/ipv4_config.ex
@@ -171,7 +171,11 @@ defmodule VintageNet.IP.IPv4Config do
                  "-s",
                  udhcpc_handler_path()
                ],
-               Command.add_muon_options(stderr_to_stdout: true, log_output: :debug)
+               Command.add_muon_options(
+                 stderr_to_stdout: true,
+                 log_output: :debug,
+                 log_prefix: "udhcpc(#{ifname}): "
+               )
              ]},
             id: :udhcpc
           ),

--- a/mix.exs
+++ b/mix.exs
@@ -97,7 +97,7 @@ defmodule VintageNet.MixProject do
       {:ex_doc, "~> 0.19", only: :docs, runtime: false},
       {:excoveralls, "~> 0.8", only: :test, runtime: false},
       {:dialyxir, "~> 1.0.0-rc.6", only: [:dev, :test], runtime: false},
-      {:muontrap, "~> 0.5.0"},
+      {:muontrap, "~> 0.5.1"},
       {:gen_state_machine, "~> 2.0.0"},
       {:busybox, "~> 0.1.4", optional: true}
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -15,7 +15,7 @@
   "makeup_elixir": {:hex, :makeup_elixir, "0.14.0", "cf8b7c66ad1cff4c14679698d532f0b5d45a3968ffbcbfd590339cb57742f1ae", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], [], "hexpm"},
   "mimerl": {:hex, :mimerl, "1.2.0", "67e2d3f571088d5cfd3e550c383094b47159f3eee8ffa08e64106cdf5e981be3", [:rebar3], [], "hexpm"},
-  "muontrap": {:hex, :muontrap, "0.5.0", "0b885a4095e990000d519441bccb8f037a9c4c35908720e7814a516a606be278", [:make, :mix], [{:elixir_make, "~> 0.6", [hex: :elixir_make, repo: "hexpm", optional: false]}], "hexpm"},
+  "muontrap": {:hex, :muontrap, "0.5.1", "98fe96d0e616ee518860803a37a29eb23ffc2ca900047cb1bb7fd37521010093", [:make, :mix], [{:elixir_make, "~> 0.6", [hex: :elixir_make, repo: "hexpm", optional: false]}], "hexpm"},
   "nimble_parsec": {:hex, :nimble_parsec, "0.5.3", "def21c10a9ed70ce22754fdeea0810dafd53c2db3219a0cd54cf5526377af1c6", [:mix], [], "hexpm"},
   "parse_trans": {:hex, :parse_trans, "3.3.0", "09765507a3c7590a784615cfd421d101aec25098d50b89d7aa1d66646bc571c1", [:rebar3], [], "hexpm"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.5", "6eaf7ad16cb568bb01753dbbd7a95ff8b91c7979482b95f38443fe2c8852a79b", [:make, :mix, :rebar3], [], "hexpm"},

--- a/test/support/utils.ex
+++ b/test/support/utils.ex
@@ -37,7 +37,7 @@ defmodule VintageNetTest.Utils do
              "-s",
              Application.app_dir(:vintage_net, ["priv", "udhcpc_handler"])
            ],
-           [stderr_to_stdout: true, log_output: :debug]
+           [stderr_to_stdout: true, log_output: :debug, log_prefix: "udhcpc(eth0): "]
          ]},
       type: :worker
     }


### PR DESCRIPTION
This makes it easier to diagnose which interface is to blame when udhcpc
starts sending output to the log.

This uses the new `:log_prefix` feature in MuonTrap, so the
dependency has been updated to force the new version.