### PR TITLE
Fix docs format for RawConfig

### DIFF
--- a/lib/vintage_net/interface/raw_config.ex
+++ b/lib/vintage_net/interface/raw_config.ex
@@ -13,7 +13,7 @@ defmodule VintageNet.Interface.RawConfig do
   * `require_interface` - require the interface to exist in the system before configuring
   * `retry_millis` - if bringing the interface up fails, wait this amount of time before retrying
   * `files` - a list of file path, content tuples
-  * `restart_strategy` - the restart strategy for the list of `child_specs`. I.e., `:one_for_one | :one_for_all | :rest_for_one
+  * `restart_strategy` - the restart strategy for the list of `child_specs`. I.e., `:one_for_one | :one_for_all | :rest_for_one`
   * `child_specs` - a set of child_specs for GenServers to start up and supervise
   * `up_cmd_millis` - the maximum amount of time to allow the up command list to take
   * `up_cmds` - a list of commands to run to configure the interface


### PR DESCRIPTION
The current docs look like:

![Screenshot from 2020-01-16 13-38-49](https://user-images.githubusercontent.com/6612164/72561158-d6834180-3865-11ea-8327-6f66e2741de6.png)


This fix makes them look like:

![Screenshot from 2020-01-16 13-39-02](https://user-images.githubusercontent.com/6612164/72561191-e733b780-3865-11ea-9876-bc9db60dd9a4.png)
