### PR TITLE
Allow passing options to deconfigure/2

### DIFF
--- a/lib/vintage_net.ex
+++ b/lib/vintage_net.ex
@@ -149,10 +149,12 @@ defmodule VintageNet do
 
   @doc """
   Deconfigure settings for a specified interface.
+
+  Supports same options as `configure/3`
   """
-  @spec deconfigure(ifname()) :: :ok | {:error, any()}
-  def deconfigure(ifname) do
-    configure(ifname, %{type: VintageNet.Technology.Null})
+  @spec deconfigure(ifname(), configure_options()) :: :ok | {:error, any()}
+  def deconfigure(ifname, options \\ []) do
+    configure(ifname, %{type: VintageNet.Technology.Null}, options)
   end
 
   @doc """


### PR DESCRIPTION
Allow passing the same options to `deconfigure/2` as `configure/3` to fix the edge case where sometimes you configure a network with `persist: false` and then try to deconfigure it, but it ignores the persistence. (`configure("wlan0", ap_config, persist: true)` then later `deconfigure("wlan0")` and reboot brings up old configure which connects to `wlan0`)