### PR TITLE
Fix VintageNet.info/0 with AP configs

### DIFF
--- a/lib/vintage_net/info.ex
+++ b/lib/vintage_net/info.ex
@@ -85,6 +85,8 @@ defmodule VintageNet.Info do
     end)
   end
 
+  defp sanitize_configuration(data), do: data
+
   defp print_if_attribute(ifname, name, print_name) do
     value = VintageNet.get(["interface", ifname, name])
     IO.puts("  #{print_name}: #{inspect(value)}")


### PR DESCRIPTION
When my wlan was configured as an AP, the config was breaking the info printout

```
iex(2)> VintageNet.info
VintageNet 0.7.3

All interfaces:       ["lo", "wlan0"]

Interface wlan0
  Type: VintageNetWiFi
  Present: true
  State: :configured
  Connection: :lan
  Configuration:
** (FunctionClauseError) no function clause matching in VintageNet.Info.sanitize_configuration/1
    The following arguments were given to VintageNet.Info.sanitize_configuration/1:
        # 1
        {192, 168, 0, 1}
    (vintage_net) lib/vintage_net/info.ex:53: VintageNet.Info.sanitize_configuration/1
    (vintage_net) lib/vintage_net/info.ex:84: anonymous fn/2 in VintageNet.Info.sanitize_configuration/1
    (elixir) lib/enum.ex:1948: Enum."-reduce/3-lists^foldl/2-0-"/3
    (vintage_net) lib/vintage_net/info.ex:71: VintageNet.Info.sanitize_configuration/1
    (elixir) lib/map.ex:216: Map.new_transform/3
    (vintage_net) lib/vintage_net/info.ex:67: VintageNet.Info.sanitize_configuration/1
    (elixir) lib/map.ex:216: Map.new_transform/3
    (vintage_net) lib/vintage_net/info.ex:67: VintageNet.Info.sanitize_configuration/1
```