### PR TITLE
Differentiate route priority of like interfaces

### DIFF
--- a/lib/vintage_net/interface/classification.ex
+++ b/lib/vintage_net/interface/classification.ex
@@ -30,6 +30,13 @@ defmodule VintageNet.Interface.Classification do
   """
   @type prioritization :: {interface_type() | :_, connection_status() | :_}
 
+  @typedoc """
+  A weight used to disambiguate interfaces that would otherwise have the same priority
+
+  Low weights are higher priority.
+  """
+  @type weight :: 0..9
+
   @doc """
   Classify a network type based on its name
 
@@ -57,6 +64,30 @@ defmodule VintageNet.Interface.Classification do
   def to_type(_other), do: :unknown
 
   @doc """
+  Extract a number out of an interface name
+
+  The result is the interface index for most interfaces seen
+  on Nerves (eth0, eth1, ...), and something quite imperfect when using predictable
+  interface naming (enp6s0, enp6s1).
+
+  This is currently used to order priorities when there are two
+  interfaces available of the same type that cannot be differentiated
+  by other means. It has the one property of being easy to explain.
+  """
+  @spec to_instance(VintageNet.ifname()) :: non_neg_integer()
+  def to_instance(ifname) do
+    ifname
+    |> String.to_charlist()
+    |> Enum.reduce(0, &add_numbers/2)
+  end
+
+  defp add_numbers(c, sum) when c >= ?0 and c <= ?9 do
+    sum * 10 + c - ?0
+  end
+
+  defp add_numbers(_c, sum), do: sum
+
+  @doc """
   Compute the routing metric for an interface with a status
 
   This uses the prioritization list to figure out what number should
@@ -64,11 +95,11 @@ defmodule VintageNet.Interface.Classification do
   to indicate that a route shouldn't be added to the Linux routing tables
   at all.
   """
-  @spec compute_metric(interface_type(), connection_status(), [prioritization()]) ::
+  @spec compute_metric(interface_type(), connection_status(), weight(), [prioritization()]) ::
           pos_integer() | :disabled
-  def compute_metric(_type, :disconnected, _prioritization), do: :disabled
+  def compute_metric(_type, :disconnected, _weight, _prioritization), do: :disabled
 
-  def compute_metric(type, status, prioritization) when status in [:lan, :internet] do
+  def compute_metric(type, status, weight, prioritization) when status in [:lan, :internet] do
     case Enum.find_index(prioritization, fn option -> matches_option?(option, type, status) end) do
       nil ->
         :disabled
@@ -76,7 +107,7 @@ defmodule VintageNet.Interface.Classification do
       value ->
         # Don't return 0, since that looks like the metric wasn't set. Also space out the numbers.
         # (Lower numbers are higher priority)
-        (value + 1) * 10
+        (value + 1) * 10 + weight
     end
   end
 

--- a/lib/vintage_net/route/interface_info.ex
+++ b/lib/vintage_net/route/interface_info.ex
@@ -1,24 +1,28 @@
 defmodule VintageNet.Route.InterfaceInfo do
   alias VintageNet.Interface.Classification
 
+  @moduledoc false
+
   defstruct default_gateway: nil,
+            weight: 0,
             ip_subnets: [],
             interface_type: :unknown,
             status: :disconnected
 
   @type t :: %__MODULE__{
           default_gateway: :inet.ip_address() | nil,
+          weight: Classification.weight(),
           ip_subnets: [{:inet.ip_address(), VintageNet.prefix_length()}],
           interface_type: Classification.interface_type(),
           status: Classification.connection_status()
         }
 
-  # @spec metric(InterfaceInfo.t(), [Classification.prioritization()]) :: :disabled | non_neg_integer()
-  @spec metric(atom() | %{interface_type: binary(), status: :disconnected | :internet | :lan}, [
+  # @spec metric(t(), [Classification.prioritization()]) :: :disabled | pos_integer()
+  @spec metric(t(), [
           {:_ | :ethernet | :local | :mobile | :unknown | :wifi,
            :_ | :disconnected | :internet | :lan}
         ]) :: :disabled | pos_integer()
   def metric(info, prioritization) do
-    Classification.compute_metric(info.interface_type, info.status, prioritization)
+    Classification.compute_metric(info.interface_type, info.status, info.weight, prioritization)
   end
 end

--- a/test/vintage_net/interface/classification_test.exs
+++ b/test/vintage_net/interface/classification_test.exs
@@ -5,7 +5,7 @@ defmodule VintageNet.Interface.ClassificationTest do
 
   doctest Classification
 
-  test "that type works" do
+  test "that to_type works" do
     assert Classification.to_type("eth0") == :ethernet
     assert Classification.to_type("eth1") == :ethernet
     assert Classification.to_type("en0") == :ethernet
@@ -16,37 +16,38 @@ defmodule VintageNet.Interface.ClassificationTest do
     assert Classification.to_type("something0") == :unknown
   end
 
+  test "that to_instance works" do
+    assert Classification.to_instance("eth0") == 0
+    assert Classification.to_instance("eth1") == 1
+    assert Classification.to_instance("en3") == 3
+    assert Classification.to_instance("enp6s0") == 60
+    assert Classification.to_instance("wlan0") == 0
+    assert Classification.to_instance("wlan1") == 1
+    assert Classification.to_instance("ppp0") == 0
+    assert Classification.to_instance("something5") == 5
+  end
+
   test "disconnected interfaces classify as disabled" do
-    assert :disabled ==
-             Classification.compute_metric(
-               :ethernet,
-               :disconnected,
-               Classification.default_prioritization()
-             )
+    priors = Classification.default_prioritization()
 
     assert :disabled ==
-             Classification.compute_metric(
-               :wifi,
-               :disconnected,
-               Classification.default_prioritization()
-             )
+             Classification.compute_metric(:ethernet, :disconnected, 0, priors)
 
     assert :disabled ==
-             Classification.compute_metric(
-               :mobile,
-               :disconnected,
-               Classification.default_prioritization()
-             )
+             Classification.compute_metric(:wifi, :disconnected, 0, priors)
+
+    assert :disabled ==
+             Classification.compute_metric(:mobile, :disconnected, 0, priors)
   end
 
   test "priorities go from wired to wireless to lte and other" do
     priors = Classification.default_prioritization()
 
     for status <- [:internet, :lan] do
-      wired = Classification.compute_metric(:ethernet, status, priors)
-      wireless = Classification.compute_metric(:wifi, status, priors)
-      lte = Classification.compute_metric(:mobile, status, priors)
-      other = Classification.compute_metric(:unknown, status, priors)
+      wired = Classification.compute_metric(:ethernet, status, 0, priors)
+      wireless = Classification.compute_metric(:wifi, status, 0, priors)
+      lte = Classification.compute_metric(:mobile, status, 0, priors)
+      other = Classification.compute_metric(:unknown, status, 0, priors)
 
       assert wired < wireless
       assert wireless < lte
@@ -58,8 +59,8 @@ defmodule VintageNet.Interface.ClassificationTest do
     priors = Classification.default_prioritization()
 
     for ifname <- [:ethernet, :wifi, :mobile, :unknown] do
-      internet = Classification.compute_metric(ifname, :internet, priors)
-      lan = Classification.compute_metric(ifname, :lan, priors)
+      internet = Classification.compute_metric(ifname, :internet, 0, priors)
+      lan = Classification.compute_metric(ifname, :lan, 0, priors)
 
       assert internet < lan
     end

--- a/test/vintage_net/route/properties_test.exs
+++ b/test/vintage_net/route/properties_test.exs
@@ -63,12 +63,14 @@ defmodule VintageNet.Route.PropertiesTest do
         "eth0" => %InterfaceInfo{
           interface_type: :ethernet,
           status: :disconnected,
+          weight: 0,
           ip_subnets: [{{192, 168, 1, 50}, 24}],
           default_gateway: {192, 168, 1, 1}
         },
         "wlan0" => %InterfaceInfo{
           interface_type: :wifi,
           status: status,
+          weight: 0,
           ip_subnets: [{{192, 168, 1, 60}, 24}],
           default_gateway: {192, 168, 1, 1}
         }


### PR DESCRIPTION
If you have two Ethernet interfaces, for example, they will now receive
different prioritizations in the Linux routing tables. This fixes an
issue where you'd get `{:error, "ip: RTNETLINK answers: File exists\n"}`
errors due to the same priority being used.

The weighting implemented is simple: eth0 is prioritized over eth1, etc.

This is intended as a first pass over this use case. There are details
beyond weighting that need to be addressed for these devices - like
predictable interface naming. It also may be desirable to join the
interfaces together at a lower level to use redundancy protocols.

Fixes #197