### PR TITLE
Split resolv.conf generation for better testing

### DIFF
--- a/lib/vintage_net/resolver/resolv_conf.ex
+++ b/lib/vintage_net/resolver/resolv_conf.ex
@@ -1,0 +1,42 @@
+defmodule VintageNet.Resolver.ResolvConf do
+  @moduledoc false
+
+  # Convert name resolver configurations into
+  # /etc/resolv.conf contents
+
+  @typedoc "Name resolver settings for an interface"
+  @type entry :: %{
+          priority: integer(),
+          domain: String.t(),
+          name_servers: [:inet.ip_address()]
+        }
+
+  @typedoc "All entries"
+  @type entry_map :: %{VintageNet.ifname() => entry()}
+
+  @spec to_config(entry_map()) :: iolist()
+  def to_config(entries) do
+    [Enum.map(entries, &domain_text/1), Enum.map(entries, &nameserver_text/1)]
+  end
+
+  defp domain_text({_ifname, %{domain: domain}}) when is_binary(domain) and domain != "",
+    do: ["search ", domain, "\n"]
+
+  defp domain_text(_), do: []
+
+  defp nameserver_text({_ifname, %{name_servers: servers}}) do
+    for server <- servers, do: ["nameserver ", ntoa!(server), "\n"]
+  end
+
+  defp nameserver_text(_), do: []
+
+  defp ntoa!(ip) do
+    case :inet.ntoa(ip) do
+      {:error, _reason} ->
+        raise ArgumentError, "Invalid IP in state: #{inspect(ip)}"
+
+      result ->
+        result
+    end
+  end
+end

--- a/test/vintage_net/name_resolver_test.exs
+++ b/test/vintage_net/name_resolver_test.exs
@@ -1,9 +1,13 @@
-defmodule VintageNet.Interface.NameResolverTest do
+defmodule VintageNet.NameResolverTest do
   use VintageNetTest.Case
   alias VintageNet.NameResolver
   import ExUnit.CaptureLog
 
-  @resolvconf_path "resolv.conf"
+  @resolvconf_path "fake_resolv.conf"
+
+  # See resolv_conf_test.exs for more involved testing of the configuration file
+  # The purpose of this set of tests is to exercise the GenServer and file writing
+  # aspects of NameResolver.
 
   setup do
     # Run the tests with the application stopped.

--- a/test/vintage_net/resolver/resolv_conf_test.exs
+++ b/test/vintage_net/resolver/resolv_conf_test.exs
@@ -1,0 +1,60 @@
+defmodule VintageNet.Resolver.ResolvConfTest do
+  use VintageNetTest.Case
+  alias VintageNet.Resolver.ResolvConf
+
+  # Helper to flatten return value
+  defp to_resolvconf(map) do
+    map
+    |> ResolvConf.to_config()
+    |> IO.iodata_to_binary()
+  end
+
+  test "empty resolvconf is empty" do
+    assert to_resolvconf(%{}) == ""
+  end
+
+  test "one interface" do
+    input = %{
+      "eth0" => %{domain: "example.com", name_servers: [{1, 1, 1, 1}, {8, 8, 8, 8}]}
+    }
+
+    output = """
+    search example.com
+    nameserver 1.1.1.1
+    nameserver 8.8.8.8
+    """
+
+    assert to_resolvconf(input) == output
+  end
+
+  test "two interface" do
+    input = %{
+      "eth0" => %{domain: "example.com", name_servers: [{1, 1, 1, 1}, {8, 8, 8, 8}]},
+      "wlan0" => %{domain: "example2.com", name_servers: [{1, 1, 1, 2}, {8, 8, 8, 9}]}
+    }
+
+    output = """
+    search example.com
+    search example2.com
+    nameserver 1.1.1.1
+    nameserver 8.8.8.8
+    nameserver 1.1.1.2
+    nameserver 8.8.8.9
+    """
+
+    assert to_resolvconf(input) == output
+  end
+
+  test "no search domain" do
+    input = %{
+      "eth0" => %{domain: nil, name_servers: [{1, 1, 1, 1}, {8, 8, 8, 8}]}
+    }
+
+    output = """
+    nameserver 1.1.1.1
+    nameserver 8.8.8.8
+    """
+
+    assert to_resolvconf(input) == output
+  end
+end


### PR DESCRIPTION
This pulls the pure part of creating resolv.conf contents into its own
module. This allows for easier testing of future additions that will
involve more complicated manipulations of the file.

A side effect of this was to fix some sloppiness around IP address
handling. This isn't a big deal now, but it should make IPv6 support
easier to handle later.