### PR TITLE
Remove duplicate resolv.conf entries

### DIFF
--- a/lib/vintage_net/resolver/resolv_conf.ex
+++ b/lib/vintage_net/resolver/resolv_conf.ex
@@ -16,24 +16,44 @@ defmodule VintageNet.Resolver.ResolvConf do
 
   @spec to_config(entry_map()) :: iolist()
   def to_config(entries) do
-    [Enum.map(entries, &domain_text/1), Enum.map(entries, &nameserver_text/1)]
+    domains = search_domains(entries)
+    name_servers = all_name_servers(entries)
+
+    [Enum.map(domains, &domain_text/1), Enum.map(name_servers, &name_server_text/1)]
   end
 
-  defp domain_text({_ifname, %{domain: domain}}) when is_binary(domain) and domain != "",
-    do: ["search ", domain, "\n"]
+  defp domain_text(domain), do: ["search ", domain, "\n"]
 
-  defp domain_text(_), do: []
+  defp name_server_text(server), do: ["nameserver ", ntoa!(server), "\n"]
 
-  defp nameserver_text({_ifname, %{name_servers: servers}}) do
-    for server <- servers, do: ["nameserver ", ntoa!(server), "\n"]
+  defp all_name_servers(entries) do
+    entries
+    |> Enum.flat_map(&name_servers/1)
+    |> Enum.uniq()
   end
 
-  defp nameserver_text(_), do: []
+  defp search_domains(entries) do
+    entries
+    |> Enum.map(&domain/1)
+    |> Enum.filter(&is_binary/1)
+    |> Enum.uniq()
+  end
+
+  defp domain({_ifname, %{domain: domain}}) when is_binary(domain) and domain != "",
+    do: domain
+
+  defp domain(_), do: nil
+
+  defp name_servers({_ifname, %{name_servers: servers}}) do
+    for server <- servers, do: server
+  end
+
+  defp name_servers(_), do: []
 
   defp ntoa!(ip) do
     case :inet.ntoa(ip) do
       {:error, _reason} ->
-        raise ArgumentError, "Invalid IP in state: #{inspect(ip)}"
+        raise ArgumentError, "Invalid IP: #{inspect(ip)}"
 
       result ->
         result

--- a/lib/vintage_net/resolver/resolv_conf.ex
+++ b/lib/vintage_net/resolver/resolv_conf.ex
@@ -1,0 +1,42 @@
+defmodule VintageNet.Resolver.ResolvConf do
+  @moduledoc false
+
+  # Convert name resolver configurations into
+  # /etc/resolv.conf contents
+
+  @typedoc "Name resolver settings for an interface"
+  @type entry :: %{
+          priority: integer(),
+          domain: String.t(),
+          name_servers: [:inet.ip_address()]
+        }
+
+  @typedoc "All entries"
+  @type entry_map :: %{VintageNet.ifname() => entry()}
+
+  @spec to_config(entry_map()) :: iolist()
+  def to_config(entries) do
+    [Enum.map(entries, &domain_text/1), Enum.map(entries, &nameserver_text/1)]
+  end
+
+  defp domain_text({_ifname, %{domain: domain}}) when is_binary(domain) and domain != "",
+    do: ["search ", domain, "\n"]
+
+  defp domain_text(_), do: []
+
+  defp nameserver_text({_ifname, %{name_servers: servers}}) do
+    for server <- servers, do: ["nameserver ", ntoa!(server), "\n"]
+  end
+
+  defp nameserver_text(_), do: []
+
+  defp ntoa!(ip) do
+    case :inet.ntoa(ip) do
+      {:error, _reason} ->
+        raise ArgumentError, "Invalid IP in state: #{inspect(ip)}"
+
+      result ->
+        result
+    end
+  end
+end

--- a/test/vintage_net/name_resolver_test.exs
+++ b/test/vintage_net/name_resolver_test.exs
@@ -1,9 +1,13 @@
-defmodule VintageNet.Interface.NameResolverTest do
+defmodule VintageNet.NameResolverTest do
   use VintageNetTest.Case
   alias VintageNet.NameResolver
   import ExUnit.CaptureLog
 
-  @resolvconf_path "resolv.conf"
+  @resolvconf_path "fake_resolv.conf"
+
+  # See resolv_conf_test.exs for more involved testing of the configuration file
+  # The purpose of this set of tests is to exercise the GenServer and file writing
+  # aspects of NameResolver.
 
   setup do
     # Run the tests with the application stopped.

--- a/test/vintage_net/resolver/resolv_conf_test.exs
+++ b/test/vintage_net/resolver/resolv_conf_test.exs
@@ -1,0 +1,60 @@
+defmodule VintageNet.Resolver.ResolvConfTest do
+  use VintageNetTest.Case
+  alias VintageNet.Resolver.ResolvConf
+
+  # Helper to flatten return value
+  defp to_resolvconf(map) do
+    map
+    |> ResolvConf.to_config()
+    |> IO.iodata_to_binary()
+  end
+
+  test "empty resolvconf is empty" do
+    assert to_resolvconf(%{}) == ""
+  end
+
+  test "one interface" do
+    input = %{
+      "eth0" => %{domain: "example.com", name_servers: [{1, 1, 1, 1}, {8, 8, 8, 8}]}
+    }
+
+    output = """
+    search example.com
+    nameserver 1.1.1.1
+    nameserver 8.8.8.8
+    """
+
+    assert to_resolvconf(input) == output
+  end
+
+  test "two interface" do
+    input = %{
+      "eth0" => %{domain: "example.com", name_servers: [{1, 1, 1, 1}, {8, 8, 8, 8}]},
+      "wlan0" => %{domain: "example2.com", name_servers: [{1, 1, 1, 2}, {8, 8, 8, 9}]}
+    }
+
+    output = """
+    search example.com
+    search example2.com
+    nameserver 1.1.1.1
+    nameserver 8.8.8.8
+    nameserver 1.1.1.2
+    nameserver 8.8.8.9
+    """
+
+    assert to_resolvconf(input) == output
+  end
+
+  test "no search domain" do
+    input = %{
+      "eth0" => %{domain: nil, name_servers: [{1, 1, 1, 1}, {8, 8, 8, 8}]}
+    }
+
+    output = """
+    nameserver 1.1.1.1
+    nameserver 8.8.8.8
+    """
+
+    assert to_resolvconf(input) == output
+  end
+end

--- a/test/vintage_net/resolver/resolv_conf_test.exs
+++ b/test/vintage_net/resolver/resolv_conf_test.exs
@@ -27,7 +27,7 @@ defmodule VintageNet.Resolver.ResolvConfTest do
     assert to_resolvconf(input) == output
   end
 
-  test "two interface" do
+  test "two interfaces" do
     input = %{
       "eth0" => %{domain: "example.com", name_servers: [{1, 1, 1, 1}, {8, 8, 8, 8}]},
       "wlan0" => %{domain: "example2.com", name_servers: [{1, 1, 1, 2}, {8, 8, 8, 9}]}
@@ -51,6 +51,23 @@ defmodule VintageNet.Resolver.ResolvConfTest do
     }
 
     output = """
+    nameserver 1.1.1.1
+    nameserver 8.8.8.8
+    """
+
+    assert to_resolvconf(input) == output
+  end
+
+  test "pruning redundant entries" do
+    input = %{
+      "eth0" => %{domain: "example.com", name_servers: [{1, 1, 1, 1}, {8, 8, 8, 8}]},
+      "eth1" => %{domain: "aaa-in-between.com", name_servers: [{1, 1, 1, 1}, {8, 8, 8, 8}]},
+      "wlan0" => %{domain: "example.com", name_servers: [{1, 1, 1, 1}, {8, 8, 8, 8}]}
+    }
+
+    output = """
+    search example.com
+    search aaa-in-between.com
     nameserver 1.1.1.1
     nameserver 8.8.8.8
     """


### PR DESCRIPTION
This fixes a case where multi-homed devices would get the same name servers
and search domains on more than one interface.

[To be merged after #202]