### PR TITLE
Force the call to Technology.normalize/1

### DIFF
--- a/lib/vintage_net/interface.ex
+++ b/lib/vintage_net/interface.ex
@@ -63,7 +63,8 @@ defmodule VintageNet.Interface do
 
     try do
       technology = technology_from_config(config)
-      raw_config = technology.to_raw_config(ifname, config, opts)
+      normalized_config = technology.normalize(config)
+      raw_config = technology.to_raw_config(ifname, normalized_config, opts)
       {:ok, raw_config}
     rescue
       error in ArgumentError -> {:error, error.message}
@@ -87,7 +88,8 @@ defmodule VintageNet.Interface do
   def configure(ifname, config) do
     opts = Application.get_all_env(:vintage_net)
     technology = technology_from_config(config)
-    raw_config = technology.to_raw_config(ifname, config, opts)
+    normalized_config = technology.normalize(config)
+    raw_config = technology.to_raw_config(ifname, normalized_config, opts)
     configure(raw_config)
   end
 

--- a/test/support/test_technology.ex
+++ b/test/support/test_technology.ex
@@ -8,14 +8,16 @@ defmodule VintageNetTest.TestTechnology do
   """
 
   @impl true
-  def normalize(config), do: config
+  def normalize(config) do
+    Map.put(config, :normalize_was_called, true)
+  end
 
   @impl true
   def to_raw_config(ifname, config \\ %{}, _opts \\ []) do
     %RawConfig{
       ifname: ifname,
       type: __MODULE__,
-      source_config: %{type: __MODULE__, test_config: config}
+      source_config: config
     }
   end
 

--- a/test/vintage_net_test.exs
+++ b/test/vintage_net_test.exs
@@ -62,6 +62,17 @@ defmodule VintageNetTest do
     assert match?({:error, _}, VintageNet.configure("eth0", %{this_totally_should_not_work: 1}))
   end
 
+  test "calls normalize" do
+    :ok = VintageNet.configure("eth0", %{type: VintageNetTest.TestTechnology})
+
+    VintageNet.Interface.wait_until_configured("eth0")
+
+    applied_config = VintageNet.get_configuration("eth0")
+
+    # See TestTechnology's normalize/1 method
+    assert Map.get(applied_config, :normalize_was_called)
+  end
+
   test "configure persists by default" do
     path = Path.join(Application.get_env(:vintage_net, :persistence_dir), "eth0")
 


### PR DESCRIPTION
This fixes an issue where the Technology documentation says that
VintageNet calls the normalize/1 function, but it actually doesn't. All
of the existing to_raw_config/3 functions called it and that masked the
lack of a call. This fixes the issue and adds a unit test to avoid it
happening again.