### PR TITLE
Store interface configuration as a property

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,7 @@ interfaces:
 Property      | Values              | Description
  ------------ | ------------------- | -----------
 `type`        | `VintageNetEthernet`, etc. | The type of the interface
+`config`      | `%{...}`            | The configuration for this interface
 `state`       | `:configured`, `:configuring`, etc. | The state of the interface from `VintageNet`'s point of view.
 `connection`  | `:disconnected`, `:lan`, `:internet` | This provides a determination of the Internet connection status
 `lower_up`    | `true` or `false`   | This indicates whether the physical layer is "up". E.g., a cable is connected or WiFi associated
@@ -350,4 +351,3 @@ Property      | Values              | Description
 `addresses`   | [address_info]      | This is a list of all of the addresses assigned to this interface
 
 Specific types of interfaces provide more parameters.
-

--- a/lib/vintage_net/interface/raw_config.ex
+++ b/lib/vintage_net/interface/raw_config.ex
@@ -3,7 +3,7 @@ defmodule VintageNet.Interface.RawConfig do
   Raw configuration for an interface
 
   This struct contains the low-level instructions for how to configure and
-  unconfigure an interface.
+  deconfigure an interface.
 
   Fields:
 
@@ -18,7 +18,7 @@ defmodule VintageNet.Interface.RawConfig do
   * `up_cmd_millis` - the maximum amount of time to allow the up command list to take
   * `up_cmds` - a list of commands to run to configure the interface
   * `down_cmd_millis` - the maximum amount of time to allow the down command list to take
-  * `down_cmds` - a list of commands to run to unconfigure the interface
+  * `down_cmds` - a list of commands to run to bring the interface down
   * `cleanup_files` - additional files to delete (the files listed in `files` are deleted too)
 
   """

--- a/lib/vintage_net/property_table.ex
+++ b/lib/vintage_net/property_table.ex
@@ -39,9 +39,12 @@ defmodule VintageNet.PropertyTable do
   @type property :: [String.t()]
   @type property_with_wildcards :: [String.t() | :_]
   @type value :: any()
+  @type property_value :: {property(), value()}
   @type metadata :: map()
 
-  @spec start_link(name: table_id()) :: {:ok, pid} | {:error, term}
+  @type options :: [name: table_id(), properties: [property_value()]]
+
+  @spec start_link(options()) :: {:ok, pid} | {:error, term}
   def start_link(options) do
     name = Keyword.get(options, :name)
 
@@ -49,7 +52,7 @@ defmodule VintageNet.PropertyTable do
       raise ArgumentError, "expected :name to be given and to be an atom, got: #{inspect(name)}"
     end
 
-    VintageNet.PropertyTable.Supervisor.start_link(name)
+    VintageNet.PropertyTable.Supervisor.start_link(options)
   end
 
   @doc """

--- a/lib/vintage_net/property_table/supervisor.ex
+++ b/lib/vintage_net/property_table/supervisor.ex
@@ -5,17 +5,19 @@ defmodule VintageNet.PropertyTable.Supervisor do
 
   @moduledoc false
 
-  @spec start_link(PropertyTable.table_id()) :: Supervisor.on_start()
-  def start_link(name) do
-    Supervisor.start_link(__MODULE__, name)
+  @spec start_link(PropertyTable.options()) :: Supervisor.on_start()
+  def start_link(options) do
+    Supervisor.start_link(__MODULE__, options)
   end
 
   @impl true
-  def init(name) do
+  def init(options) do
+    name = Keyword.fetch!(options, :name)
+    properties = Keyword.get(options, :properties, [])
     registry_name = registry_name(name)
 
     children = [
-      {VintageNet.PropertyTable.Table, {name, registry_name}},
+      {VintageNet.PropertyTable.Table, {name, registry_name, properties}},
       {Registry, [keys: :duplicate, name: registry_name]}
     ]
 

--- a/test/support/test_case.ex
+++ b/test/support/test_case.ex
@@ -2,6 +2,7 @@ defmodule VintageNetTest.Case do
   @moduledoc false
 
   use ExUnit.CaseTemplate
+  import ExUnit.CaptureLog
 
   using do
     quote do
@@ -15,6 +16,10 @@ defmodule VintageNetTest.Case do
     _ = File.rm_rf!(path)
     File.mkdir_p!(path)
     File.cd!(path, function)
+  end
+
+  def capture_log_in_tmp(which, function) do
+    capture_log(fn -> in_tmp(which, function) end)
   end
 
   def tmp_path() do

--- a/test/support/test_technology.ex
+++ b/test/support/test_technology.ex
@@ -14,11 +14,38 @@ defmodule VintageNetTest.TestTechnology do
 
   @impl true
   def to_raw_config(ifname, config \\ %{}, _opts \\ []) do
+    # Let tests inject raw config keys if they specify them.
+    # Otherwise, use whatever the defaults are.
     %RawConfig{
       ifname: ifname,
       type: __MODULE__,
       source_config: config
     }
+    |> maybe_put(config, [
+      :files,
+      :require_interface,
+      :up_cmds,
+      :down_cmds,
+      :cleanup_files,
+      :retry_millis,
+      :up_cmd_millis,
+      :down_cmd_millis,
+      :child_specs
+    ])
+  end
+
+  defp maybe_put(raw_config, config, keys) do
+    Enum.reduce(keys, raw_config, &maybe_put_key(&2, config, &1))
+  end
+
+  defp maybe_put_key(raw_config, config, key) do
+    case Map.fetch(config, key) do
+      {:ok, value} ->
+        Map.put(raw_config, key, value)
+
+      _ ->
+        raw_config
+    end
   end
 
   @impl true

--- a/test/vintage_net/property_table_test.exs
+++ b/test/vintage_net/property_table_test.exs
@@ -5,12 +5,19 @@ defmodule VintageNet.PropertyTableTest do
 
   doctest PropertyTable
 
-  setup config do
-    {:ok, _pid} = start_supervised({PropertyTable, name: config.test})
-    {:ok, %{table: config.test}}
+  test "start with initial properties", %{test: table} do
+    name1 = ["test", "a", "b"]
+    name2 = ["test", "c"]
+
+    {:ok, _pid} =
+      start_supervised({PropertyTable, properties: [{name1, 1}, {name2, 2}], name: table})
+
+    assert PropertyTable.get(table, name1) == 1
+    assert PropertyTable.get(table, name2) == 2
   end
 
-  test "wildcard subscription", %{table: table} do
+  test "wildcard subscription", %{test: table} do
+    {:ok, _pid} = start_supervised({PropertyTable, name: table})
     PropertyTable.subscribe(table, ["a", :_, "c"])
 
     # Exact match
@@ -29,7 +36,8 @@ defmodule VintageNet.PropertyTableTest do
     refute_receive {^table, ["a", "b", "d"], _, _, _}
   end
 
-  test "getting invalid properties raises", %{table: table} do
+  test "getting invalid properties raises", %{test: table} do
+    {:ok, _pid} = start_supervised({PropertyTable, name: table})
     # Wildcards aren't allowed
     assert_raise ArgumentError, fn -> PropertyTable.get(table, [:_, "a"]) end
     assert_raise ArgumentError, fn -> PropertyTable.get(table, [:_]) end
@@ -39,7 +47,8 @@ defmodule VintageNet.PropertyTableTest do
     assert_raise ArgumentError, fn -> PropertyTable.get(table, ["a", 5]) end
   end
 
-  test "sending events", %{table: table} do
+  test "sending events", %{test: table} do
+    {:ok, _pid} = start_supervised({PropertyTable, name: table})
     name = ["test"]
     PropertyTable.subscribe(table, name)
 
@@ -55,7 +64,8 @@ defmodule VintageNet.PropertyTableTest do
     PropertyTable.unsubscribe(table, name)
   end
 
-  test "setting properties to nil clears them", %{table: table} do
+  test "setting properties to nil clears them", %{test: table} do
+    {:ok, _pid} = start_supervised({PropertyTable, name: table})
     name = ["test"]
 
     PropertyTable.put(table, name, 124)
@@ -65,7 +75,8 @@ defmodule VintageNet.PropertyTableTest do
     assert PropertyTable.get_by_prefix(table, []) == []
   end
 
-  test "generic subscribers receive events", %{table: table} do
+  test "generic subscribers receive events", %{test: table} do
+    {:ok, _pid} = start_supervised({PropertyTable, name: table})
     name = ["test", "a", "b"]
 
     PropertyTable.subscribe(table, [])
@@ -74,7 +85,8 @@ defmodule VintageNet.PropertyTableTest do
     PropertyTable.unsubscribe(table, [])
   end
 
-  test "duplicate events are dropped", %{table: table} do
+  test "duplicate events are dropped", %{test: table} do
+    {:ok, _pid} = start_supervised({PropertyTable, name: table})
     name = ["test", "a", "b"]
 
     PropertyTable.subscribe(table, name)
@@ -86,7 +98,8 @@ defmodule VintageNet.PropertyTableTest do
     PropertyTable.unsubscribe(table, name)
   end
 
-  test "getting the latest", %{table: table} do
+  test "getting the latest", %{test: table} do
+    {:ok, _pid} = start_supervised({PropertyTable, name: table})
     name = ["test", "a", "b"]
     assert PropertyTable.get(table, name) == nil
 
@@ -97,7 +110,8 @@ defmodule VintageNet.PropertyTableTest do
     assert PropertyTable.get(table, name) == 106
   end
 
-  test "fetching data with timestamps", %{table: table} do
+  test "fetching data with timestamps", %{test: table} do
+    {:ok, _pid} = start_supervised({PropertyTable, name: table})
     name = ["test", "a", "b"]
     assert :error == PropertyTable.fetch_with_timestamp(table, name)
 
@@ -114,7 +128,8 @@ defmodule VintageNet.PropertyTableTest do
     assert now - timestamp < 1_000_000
   end
 
-  test "getting a subtree", %{table: table} do
+  test "getting a subtree", %{test: table} do
+    {:ok, _pid} = start_supervised({PropertyTable, name: table})
     name = ["test", "a", "b"]
     name2 = ["test", "a", "c"]
 
@@ -131,7 +146,8 @@ defmodule VintageNet.PropertyTableTest do
     assert PropertyTable.get_by_prefix(table, name2) == [{name2, 106}]
   end
 
-  test "clearing a subtree", %{table: table} do
+  test "clearing a subtree", %{test: table} do
+    {:ok, _pid} = start_supervised({PropertyTable, name: table})
     PropertyTable.put(table, ["a", "b", "c"], 1)
     PropertyTable.put(table, ["a", "b", "d"], 2)
     PropertyTable.put(table, ["a", "b", "e"], 3)
@@ -141,7 +157,8 @@ defmodule VintageNet.PropertyTableTest do
     assert PropertyTable.get_by_prefix(table, []) == [{["f", "g"], 4}]
   end
 
-  test "match using wildcards", %{table: table} do
+  test "match using wildcards", %{test: table} do
+    {:ok, _pid} = start_supervised({PropertyTable, name: table})
     PropertyTable.put(table, ["a", "b", "c"], 1)
     PropertyTable.put(table, ["A", "b", "c"], 2)
     PropertyTable.put(table, ["a", "B", "c"], 3)


### PR DESCRIPTION
This is a decent-sized refactor to store interface configuration as properties. See the commit messages for full details. 

The first commit adds support to populate the property tables when they're first started. This removes a hypothetical race condition between initialization and having the tables contain the initial configuration. It also made it simpler to load the configuration at application start and have it appear in the property table.

The second commit makes the refactor to store the interface configuration in properties. It affected a lot of code as I double checked quite a few unit tests and improved them to test the refactor. 

I believe that this will fix the race condition in #213 since configurations are all loaded into memory by the time VintageNet's application start returns. Therefore, if any changes happen after that, there's no chance any more of them being overwritten. Or similarly, there's no chance of configurations being checked after application start and not catching them before they're loaded from disk.