### PR TITLE
Fix wrong IP address being used for ppp links

### DIFF
--- a/lib/vintage_net/interfaces_monitor.ex
+++ b/lib/vintage_net/interfaces_monitor.ex
@@ -8,6 +8,8 @@ defmodule VintageNet.InterfacesMonitor do
 
   use GenServer
 
+  # require Logger
+
   alias VintageNet.InterfacesMonitor.Info
 
   defmodule State do
@@ -67,8 +69,9 @@ defmodule VintageNet.InterfacesMonitor do
 
   @impl true
   def handle_info({_port, {:data, raw_report}}, state) do
-    # IO.puts("Got: #{inspect(raw_report, limit: :infinity)}")
     report = :erlang.binary_to_term(raw_report)
+
+    #  Logger.debug("if_monitor: #{inspect(report, limit: :infinity)}")
 
     new_state = handle_report(state, report)
 

--- a/lib/vintage_net/interfaces_monitor/info.ex
+++ b/lib/vintage_net/interfaces_monitor/info.ex
@@ -76,6 +76,26 @@ defmodule VintageNet.InterfacesMonitor.Info do
     scope: :universe
   }
   ```
+
+  or
+
+  ```elixir
+  %{
+    address: {10, 64, 64, 64},
+    family: :inet,
+    label: "ppp0",
+    local: {10, 0, 95, 181},
+    permanent: true,
+    prefixlen: 32,
+    scope: :universe
+  }
+  ```
+
+  or
+
+  ```elixir
+  %{address: {0, 0, 0, 0, 0, 0, 0, 1}, family: :inet6, permanent: true, prefixlen: 128, scope: :host}
+  ```
   """
   @spec newaddr(t(), map()) :: t()
   def newaddr(info, address_report) do
@@ -160,11 +180,17 @@ defmodule VintageNet.InterfacesMonitor.Info do
   end
 
   defp address_reports_to_property(address_reports) do
+    # VintageNet uses the word `address` to refer to the IP address assigned to
+    # the interface. If you don't know Linux networking, I think that's an
+    # obvious use of that word. For point-to-point network links, though, Linux
+    # reports both the local and remote addresses. The remote one is stored in
+    # `address` and the local one is in `local`. Therefore, the code below uses
+    # `local` since that's always the local side of the interface.
     for report <- address_reports do
       %{
         family: report.family,
         scope: report.scope,
-        address: report.address,
+        address: report[:local] || report.address,
         prefix_length: report.prefixlen,
         netmask: IP.prefix_length_to_subnet_mask(report.family, report.prefixlen)
       }

--- a/test/vintage_net/interfaces_monitor_test.exs
+++ b/test/vintage_net/interfaces_monitor_test.exs
@@ -179,6 +179,36 @@ defmodule VintageNet.InterfacesMonitorTest do
                     [^expected_address_info], %{}}
   end
 
+  test "ipv4 ppp address gets reported correctly" do
+    VintageNet.subscribe(["interface", "bogus0", "addresses"])
+
+    send_report({:newlink, "bogus0", 56, %{}})
+
+    send_report(
+      {:newaddr, 56,
+       %{
+         address: {10, 64, 64, 64},
+         family: :inet,
+         label: "bogus0",
+         local: {10, 0, 95, 181},
+         permanent: true,
+         prefixlen: 32,
+         scope: :universe
+       }}
+    )
+
+    expected_address_info = %{
+      family: :inet,
+      scope: :universe,
+      address: {10, 0, 95, 181},
+      netmask: {255, 255, 255, 255},
+      prefix_length: 32
+    }
+
+    assert_receive {VintageNet, ["interface", "bogus0", "addresses"], _before,
+                    [^expected_address_info], %{}}
+  end
+
   test "ipv6 addresses get reported" do
     VintageNet.subscribe(["interface", "bogus0", "addresses"])
 


### PR DESCRIPTION
Linux reports the local IP address of a ppp link using the `:local` key
rather than the `:address` key. The latter key is for the remote side of
the link. For the standard "broadcast" network links, both `:local` and
`:address` are set the same so it didn't matter.

This fixes the issue, adds a test and leaves a note since this seems
unintuitive.