### PR TITLE
Explicitly listen for IPv6 address changes

### DIFF
--- a/src/if_monitor.c
+++ b/src/if_monitor.c
@@ -86,7 +86,7 @@ static void netif_init(struct netif *nb)
     if (!nb->nl_addr)
         err(EXIT_FAILURE, "mnl_socket_open (NETLINK_ROUTE)");
 
-    if (mnl_socket_bind(nb->nl_addr, RTMGRP_IPV4_IFADDR, MNL_SOCKET_AUTOPID) < 0)
+    if (mnl_socket_bind(nb->nl_addr, RTMGRP_IPV4_IFADDR | RTMGRP_IPV6_IFADDR, MNL_SOCKET_AUTOPID) < 0)
         err(EXIT_FAILURE, "mnl_socket_bind(RTMGRP_IPV4_IFADDR)");
 }
 


### PR DESCRIPTION
Previously, if_monitor received IPv6 addresses based on polling for them
at startup. However, it wouldn't receive notifications afterwards due to
limiting the registration on the netlink socket to IPv4-only.
This fixes that.