### PR TITLE
Detect unexpected exits from if_monitor

### DIFF
--- a/lib/vintage_net/interfaces_monitor.ex
+++ b/lib/vintage_net/interfaces_monitor.ex
@@ -42,7 +42,7 @@ defmodule VintageNet.InterfacesMonitor do
 
     case File.exists?(executable) do
       true ->
-        port = Port.open({:spawn_executable, executable}, [{:packet, 2}, :use_stdio, :binary])
+        port = Port.open({:spawn_executable, executable}, [{:packet, 2}, :use_stdio, :binary, :exit_status])
 
         {:ok, %State{port: port}}
 


### PR DESCRIPTION
Killing the if_monitor process went undetected. This adds `:exit_status`
to starting the port so that the exit message will bounce the GenServer
and restart the everything.