### PR TITLE
Support waiting for multiple interfaces

### DIFF
--- a/lib/vintage_net/interface/raw_config.ex
+++ b/lib/vintage_net/interface/raw_config.ex
@@ -10,7 +10,7 @@ defmodule VintageNet.Interface.RawConfig do
   * `ifname` - the name of the interface (e.g., `"eth0"`)
   * `type` - the type of network interface (aka the module that created the config)
   * `source_config` - the configuration that generated this one
-  * `require_interface` - require the interface to exist in the system before configuring
+  * `required_ifnames` - a list of ifnames that need to exist before starting this configuration. (e.g. `["eth0"]`)
   * `retry_millis` - if bringing the interface up fails, wait this amount of time before retrying
   * `files` - a list of file path, content tuples
   * `restart_strategy` - the restart strategy for the list of `child_specs`. I.e., `:one_for_one | :one_for_all | :rest_for_one`
@@ -34,11 +34,11 @@ defmodule VintageNet.Interface.RawConfig do
 
   @type file_contents :: {Path.t(), String.t()}
 
-  @enforce_keys [:ifname, :type, :source_config]
+  @enforce_keys [:ifname, :type, :source_config, :required_ifnames]
   defstruct ifname: nil,
             type: nil,
             source_config: %{},
-            require_interface: true,
+            required_ifnames: [],
             retry_millis: 30_000,
             files: [],
             restart_strategy: :one_for_all,
@@ -53,7 +53,7 @@ defmodule VintageNet.Interface.RawConfig do
           ifname: VintageNet.ifname(),
           type: atom(),
           source_config: map(),
-          require_interface: boolean(),
+          required_ifnames: [VintageNet.ifname()],
           retry_millis: non_neg_integer(),
           files: [file_contents()],
           restart_strategy: Supervisor.strategy(),

--- a/lib/vintage_net/technology/null.ex
+++ b/lib/vintage_net/technology/null.ex
@@ -18,7 +18,7 @@ defmodule VintageNet.Technology.Null do
       ifname: ifname,
       type: __MODULE__,
       source_config: @null_config,
-      require_interface: false
+      required_ifnames: []
     }
   end
 

--- a/test/support/test_technology.ex
+++ b/test/support/test_technology.ex
@@ -19,7 +19,8 @@ defmodule VintageNetTest.TestTechnology do
     %RawConfig{
       ifname: ifname,
       type: __MODULE__,
-      source_config: config
+      source_config: config,
+      required_ifnames: [ifname]
     }
     |> maybe_put(config, [
       :files,
@@ -30,7 +31,8 @@ defmodule VintageNetTest.TestTechnology do
       :retry_millis,
       :up_cmd_millis,
       :down_cmd_millis,
-      :child_specs
+      :child_specs,
+      :required_ifnames
     ])
   end
 

--- a/test/support/utils.ex
+++ b/test/support/utils.ex
@@ -39,7 +39,7 @@ defmodule VintageNetTest.Utils do
              "-s",
              Application.app_dir(:vintage_net, ["priv", "udhcpc_handler"])
            ],
-           [stderr_to_stdout: true, log_output: :debug, log_prefix: "udhcpc(eth0): "]
+           [stderr_to_stdout: true, log_output: :debug, log_prefix: "udhcpc(#{ifname}): "]
          ]},
       type: :worker
     }

--- a/test/vintage_net/ip/dhcpd_config_test.exs
+++ b/test/vintage_net/ip/dhcpd_config_test.exs
@@ -136,7 +136,8 @@ defmodule VintageNet.IP.DhcpdConfigTest do
     initial_raw_config = %VintageNet.Interface.RawConfig{
       ifname: "eth0",
       source_config: input,
-      type: UnitTest
+      type: UnitTest,
+      required_ifnames: ["eth0"]
     }
 
     opts = [tmpdir: "tmpdir", bin_udhcpd: "udhcpd"]
@@ -191,7 +192,8 @@ defmodule VintageNet.IP.DhcpdConfigTest do
       ],
       ifname: "eth0",
       source_config: input,
-      type: UnitTest
+      type: UnitTest,
+      required_ifnames: ["eth0"]
     }
 
     assert expected == result

--- a/test/vintage_net/ip/dnsd_config_test.exs
+++ b/test/vintage_net/ip/dnsd_config_test.exs
@@ -41,7 +41,8 @@ defmodule VintageNet.IP.DnsdConfigTest do
     initial_raw_config = %VintageNet.Interface.RawConfig{
       ifname: "eth0",
       source_config: input,
-      type: UnitTest
+      type: UnitTest,
+      required_ifnames: ["eth0"]
     }
 
     opts = [tmpdir: "tmpdir", bin_dnsd: "dnsd"]
@@ -73,7 +74,8 @@ defmodule VintageNet.IP.DnsdConfigTest do
       ],
       ifname: "eth0",
       source_config: input,
-      type: UnitTest
+      type: UnitTest,
+      required_ifnames: ["eth0"]
     }
 
     assert expected == result

--- a/test/vintage_net/ip/ipv4_config_test.exs
+++ b/test/vintage_net/ip/ipv4_config_test.exs
@@ -74,13 +74,15 @@ defmodule VintageNet.IP.IPv4ConfigTest do
     initial_raw_config = %VintageNet.Interface.RawConfig{
       ifname: "eth0",
       source_config: input,
-      type: UnitTest
+      type: UnitTest,
+      required_ifnames: ["eth0"]
     }
 
     expected = %VintageNet.Interface.RawConfig{
       type: UnitTest,
       ifname: "eth0",
       source_config: input,
+      required_ifnames: ["eth0"],
       child_specs: [
         udhcpc_child_spec("eth0", "unit_test"),
         {VintageNet.Interface.InternetConnectivityChecker, "eth0"}
@@ -113,6 +115,7 @@ defmodule VintageNet.IP.IPv4ConfigTest do
     initial_raw_config = %VintageNet.Interface.RawConfig{
       ifname: "eth0",
       source_config: input,
+      required_ifnames: ["eth0"],
       type: UnitTest
     }
 
@@ -120,6 +123,7 @@ defmodule VintageNet.IP.IPv4ConfigTest do
       type: UnitTest,
       ifname: "eth0",
       source_config: input,
+      required_ifnames: ["eth0"],
       child_specs: [
         {VintageNet.Interface.InternetConnectivityChecker, "eth0"}
       ],
@@ -158,6 +162,7 @@ defmodule VintageNet.IP.IPv4ConfigTest do
     initial_raw_config = %VintageNet.Interface.RawConfig{
       ifname: "eth0",
       source_config: input,
+      required_ifnames: ["eth0"],
       type: UnitTest
     }
 
@@ -165,6 +170,7 @@ defmodule VintageNet.IP.IPv4ConfigTest do
       type: UnitTest,
       ifname: "eth0",
       source_config: input,
+      required_ifnames: ["eth0"],
       child_specs: [
         {VintageNet.Interface.LANConnectivityChecker, "eth0"}
       ],
@@ -202,6 +208,7 @@ defmodule VintageNet.IP.IPv4ConfigTest do
     initial_raw_config = %VintageNet.Interface.RawConfig{
       ifname: "eth0",
       source_config: input,
+      required_ifnames: ["eth0"],
       type: UnitTest
     }
 
@@ -209,6 +216,7 @@ defmodule VintageNet.IP.IPv4ConfigTest do
       type: UnitTest,
       ifname: "eth0",
       source_config: input,
+      required_ifnames: ["eth0"],
       child_specs: [
         {VintageNet.Interface.LANConnectivityChecker, "eth0"}
       ],

--- a/test/vintage_net/technology/null_test.exs
+++ b/test/vintage_net/technology/null_test.exs
@@ -19,7 +19,7 @@ defmodule VintageNet.Technology.NullTest do
       type: VintageNet.Technology.Null,
       ifname: "eth0",
       source_config: input,
-      require_interface: false
+      required_ifnames: []
     }
 
     assert output == Null.to_raw_config("eth0", input, [])


### PR DESCRIPTION
This is an API breaking change to fix an issue where technologies needed
to either wait for multiple interfaces to be present or wait for an
interface that was different from the one that it managed.

For example, cellular modems use PPP interfaces (e.g., ppp0), but that's
an interface that they bring up. It's common that they wait for `wwan0`
to exist first.

Another example are bridges that need to wait for the networks they're
supposed to bridge to become present before they're brought up.

All technologies need to change the RawConfig structs they generate to
use this feature. You will receive a compiler error, so it should be
hard to miss. First, update your `mix` dependencies to require
`:vintage_net, "~> 0.8.0"` to force the version update. Then whereever
you're creating the RawConfig, if you had `require_interface: false`,
change that to `required_ifnames: []`. If you did nothing (most
technologies), then you'll want to require the interface that you're
using. I.e., `required_ifnames: [ifname]`.