### PR TITLE
Stop interface GenServers before running down cmds

### DIFF
--- a/lib/vintage_net/interface.ex
+++ b/lib/vintage_net/interface.ex
@@ -355,7 +355,7 @@ defmodule VintageNet.Interface do
     debug(data, ":configured -> internal configure (#{inspect(new_config.type)})")
 
     {new_data, actions} = cancel_ioctls(data)
-
+    VintageNet.Interface.Supervisor.clear_technology(data.ifname)
     new_data = run_commands(new_data, old_config.down_cmds)
 
     actions = [
@@ -376,6 +376,7 @@ defmodule VintageNet.Interface do
     debug(data, ":configured -> configure (#{inspect(new_config.type)})")
 
     {new_data, actions} = cancel_ioctls(data)
+    VintageNet.Interface.Supervisor.clear_technology(data.ifname)
     new_data = run_commands(new_data, old_config.down_cmds)
 
     actions = [
@@ -452,7 +453,7 @@ defmodule VintageNet.Interface do
     debug(data, ":configured -> interface disappeared")
 
     {new_data, actions} = cancel_ioctls(data)
-
+    VintageNet.Interface.Supervisor.clear_technology(data.ifname)
     new_data = run_commands(new_data, config.down_cmds)
 
     actions = [


### PR DESCRIPTION
This stops all interface technology GenServers when the interface goes
down. Previously they'd be left up, but they only generate errors if
technology implementers aren't careful. This also brings symmetry to the
interface lifecycle since before the interface's up command list is run
the first time, the GenServers weren't running.

The main noticable affect of this commit is to clean up logs when
interfaces disappear (via hot plug, reset, etc.).