### PR TITLE
Remove _ = on all Logger calls

### DIFF
--- a/lib/vintage_net/application.ex
+++ b/lib/vintage_net/application.ex
@@ -97,7 +97,7 @@ defmodule VintageNet.Application do
         Map.put(configs, ifname, config)
 
       {:error, reason} ->
-        _ = Logger.warn("VintageNet(#{ifname}): ignoring saved config due to #{inspect(reason)}")
+        Logger.warn("VintageNet(#{ifname}): ignoring saved config due to #{inspect(reason)}")
 
         configs
     end

--- a/lib/vintage_net/interface.ex
+++ b/lib/vintage_net/interface.ex
@@ -196,8 +196,7 @@ defmodule VintageNet.Interface do
   defp debug(data, message), do: log(:debug, data, message)
 
   defp log(level, data, message) do
-    _ = Logger.log(level, ["VintageNet(", data.ifname, "): ", message])
-    :ok
+    Logger.log(level, ["VintageNet(", data.ifname, "): ", message])
   end
 
   @impl true

--- a/lib/vintage_net/interface/command_runner.ex
+++ b/lib/vintage_net/interface/command_runner.ex
@@ -46,7 +46,7 @@ defmodule VintageNet.Interface.CommandRunner do
         :ok
 
       {_, not_zero} ->
-        _ = Logger.error("Nonzero exit from #{command}, #{inspect(args)}: #{not_zero}")
+        Logger.error("Nonzero exit from #{command}, #{inspect(args)}: #{not_zero}")
         {:error, :non_zero_exit}
     end
   end

--- a/lib/vintage_net/interface/internet_connectivity_checker.ex
+++ b/lib/vintage_net/interface/internet_connectivity_checker.ex
@@ -110,16 +110,15 @@ defmodule VintageNet.Interface.InternetConnectivityChecker do
 
         {:error, reason} ->
           if strikes < @max_fails_in_a_row do
-            _ =
-              Logger.debug(
-                "#{ifname}: Internet test failed (#{inspect(reason)}: #{strikes + 1}/#{
-                  @max_fails_in_a_row
-                } strikes"
-              )
+            Logger.debug(
+              "#{ifname}: Internet test failed (#{inspect(reason)}: #{strikes + 1}/#{
+                @max_fails_in_a_row
+              } strikes"
+            )
 
             {:internet, strikes + 1}
           else
-            _ = Logger.debug("#{ifname}: Internet test failed: (#{inspect(reason)})")
+            Logger.debug("#{ifname}: Internet test failed: (#{inspect(reason)})")
             {:lan, @max_fails_in_a_row}
           end
       end

--- a/lib/vintage_net/interface/udhcpc.ex
+++ b/lib/vintage_net/interface/udhcpc.ex
@@ -12,7 +12,7 @@ defmodule VintageNet.Interface.Udhcpc do
   """
   @impl true
   def deconfig(ifname, info) do
-    _ = Logger.info("#{ifname} dhcp deconfig: #{inspect(info)}")
+    Logger.info("#{ifname} dhcp deconfig: #{inspect(info)}")
 
     # If there were any IPv4 addresses reported on this interface, remove them
     # now. They may not be reported by the normal mechanism from the
@@ -49,7 +49,7 @@ defmodule VintageNet.Interface.Udhcpc do
   def leasefail(ifname, _info) do
     # NOTE: This message tends to clog up logs, so be careful when enabling it.
 
-    # _ = Logger.info("#{ifname} dhcp leasefail: #{inspect(info)}")
+    # Logger.info("#{ifname} dhcp leasefail: #{inspect(info)}")
     RouteManager.clear_route(ifname)
     # if [ -x /usr/sbin/avahi-autoipd ]; then
     # 	/usr/sbin/avahi-autoipd -wD $interface --no-chroot
@@ -86,7 +86,7 @@ defmodule VintageNet.Interface.Udhcpc do
   """
   @impl true
   def renew(ifname, info) do
-    _ = Logger.debug("udhcpc.renew(#{ifname}): #{inspect(info)}")
+    Logger.debug("udhcpc.renew(#{ifname}): #{inspect(info)}")
 
     # [ -n "$broadcast" ] && BROADCAST="broadcast $broadcast"
     # [ -n "$subnet" ] && NETMASK="netmask $subnet"

--- a/lib/vintage_net/interface/udhcpd.ex
+++ b/lib/vintage_net/interface/udhcpd.ex
@@ -15,7 +15,7 @@ defmodule VintageNet.Interface.Udhcpd do
         )
 
       {:error, _} ->
-        _ = Logger.error("#{ifname}: Failed to handle lease update from #{lease_file}")
+        Logger.error("#{ifname}: Failed to handle lease update from #{lease_file}")
 
         VintageNet.PropertyTable.clear_prefix(VintageNet, ["interface", ifname, "dhcpd", "leases"])
     end

--- a/lib/vintage_net/route/ip_route.ex
+++ b/lib/vintage_net/route/ip_route.ex
@@ -184,7 +184,7 @@ defmodule VintageNet.Route.IPRoute do
 
   defp ip_cmd(args) do
     # Send iodata to the logger with the command and args interspersed with spaces
-    # _ = Logger.debug(Enum.intersperse(["ip" | args], " "))
+    # Logger.debug(Enum.intersperse(["ip" | args], " "))
 
     case Command.cmd(:bin_ip, args, stderr_to_stdout: true) do
       {_, 0} -> :ok

--- a/lib/vintage_net/route_manager.ex
+++ b/lib/vintage_net/route_manager.ex
@@ -123,7 +123,7 @@ defmodule VintageNet.RouteManager do
 
   @impl true
   def handle_call({:set_route, ifname, ip_subnets, default_gateway, status}, _from, state) do
-    _ = Logger.info("RouteManager: set_route #{ifname} -> #{inspect(status)}")
+    Logger.info("RouteManager: set_route #{ifname} -> #{inspect(status)}")
 
     # The weight parameter prioritizes interfaces of the same type and connectivity.
     # All weights for interfaces of the same time must be different. I.e., we don't
@@ -165,7 +165,7 @@ defmodule VintageNet.RouteManager do
   def handle_call({:clear_route, ifname}, _from, state) do
     new_state =
       if Map.has_key?(state.interfaces, ifname) do
-        _ = Logger.info("RouteManager: clear_route #{ifname}")
+        Logger.info("RouteManager: clear_route #{ifname}")
 
         %{state | interfaces: Map.delete(state.interfaces, ifname)}
         |> update_route_tables()
@@ -198,8 +198,7 @@ defmodule VintageNet.RouteManager do
 
       ifentry ->
         if ifentry.status != new_status do
-          _ =
-            Logger.info("RouteManager: set_connection_status #{ifname} -> #{inspect(new_status)}")
+          Logger.info("RouteManager: set_connection_status #{ifname} -> #{inspect(new_status)}")
 
           put_in(state.interfaces[ifname].status, new_status)
           |> update_route_tables()

--- a/lib/vintage_net/to_elixir/server.ex
+++ b/lib/vintage_net/to_elixir/server.ex
@@ -61,12 +61,12 @@ defmodule VintageNet.ToElixir.Server do
 
   defp dispatch({["to_elixir" | args], _env}) do
     message = Enum.join(args, " ")
-    _ = Logger.debug("Got a generic message: #{message}")
+    Logger.debug("Got a generic message: #{message}")
     :ok
   end
 
   defp dispatch(unknown) do
-    _ = Logger.error("to_elixir: dropping unknown report '#{inspect(unknown)}''")
+    Logger.error("to_elixir: dropping unknown report '#{inspect(unknown)}''")
     :ok
   end
 


### PR DESCRIPTION
Elixir 1.10's Logger calls only return :ok now, so the return value no
longer needs to be ignored to make Dialyzer happy.