### PR TITLE
Add hw_path property to interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,7 @@ Property      | Values              | Description
 `type`        | `VintageNetEthernet`, etc. | The type of the interface
 `config`      | `%{...}`            | The configuration for this interface
 `state`       | `:configured`, `:configuring`, etc. | The state of the interface from `VintageNet`'s point of view.
+`hw_path`     | `"/devices/platform/ocp/4a100000.ethernet"` | This is how Linux internally views the connections going to the interface.
 `connection`  | `:disconnected`, `:lan`, `:internet` | This provides a determination of the Internet connection status
 `lower_up`    | `true` or `false`   | This indicates whether the physical layer is "up". E.g., a cable is connected or WiFi associated
 `mac_address` | "11:22:33:44:55:66" | The interface's MAC address as a string

--- a/lib/vintage_net/interfaces_monitor.ex
+++ b/lib/vintage_net/interfaces_monitor.ex
@@ -10,7 +10,7 @@ defmodule VintageNet.InterfacesMonitor do
 
   # require Logger
 
-  alias VintageNet.InterfacesMonitor.Info
+  alias VintageNet.InterfacesMonitor.{HWPath, Info}
 
   defmodule State do
     @moduledoc false
@@ -139,7 +139,9 @@ defmodule VintageNet.InterfacesMonitor do
         |> Info.update_address_properties()
 
       _missing ->
-        Info.new(ifname)
+        hw_path = HWPath.query(ifname)
+
+        Info.new(ifname, hw_path)
         |> Info.update_present()
     end
   end

--- a/lib/vintage_net/interfaces_monitor/hw_path.ex
+++ b/lib/vintage_net/interfaces_monitor/hw_path.ex
@@ -1,0 +1,51 @@
+defmodule VintageNet.InterfacesMonitor.HWPath do
+  @moduledoc false
+
+  @doc """
+  Figure out the hardware path to the interface
+
+  This returns Linux's view of the network interface's location
+  in the system. There is an assumption that Linux does not change
+  hardware layout representations between kernel versions.
+
+  This is similar to `DEVPATH` when running `udevadm info` on
+  a desktop Linux system. The difference is that this trims off
+  the network interface part of the path. So in desktop Linux,
+  you'd see:
+
+  ```
+  DEVPATH=/devices/platform/scb/fd580000.genet/net/eth0
+  ```
+
+  Whereas `query/1` would return:
+
+  ```
+  /devices/platform/scb/fd580000.genet
+  ```
+
+  The final part can be reattached if you know the `ifname`. Since
+  Linux allows you to rename network interfaces, that last part of
+  the `DEVPATH` can change without anything changing with the
+  hardware. That's why it's left off of the path here.
+  """
+  @spec query(VintageNet.ifname()) :: Path.t()
+  def query(ifname) do
+    case File.read_link("/sys/class/net/" <> ifname) do
+      {:ok, link_path} ->
+        symlink_to_hw_path(link_path, ifname)
+
+      {:error, _any} ->
+        ""
+    end
+  end
+
+  @doc """
+  Compute the hardware path from Linux's network interface symlink
+  """
+  @spec symlink_to_hw_path(Path.t(), VintageNet.ifname()) :: Path.t()
+  def symlink_to_hw_path(path, ifname) do
+    path
+    |> String.trim_leading("../..")
+    |> String.trim_trailing("/net/" <> ifname)
+  end
+end

--- a/lib/vintage_net/interfaces_monitor/info.ex
+++ b/lib/vintage_net/interfaces_monitor/info.ex
@@ -6,20 +6,26 @@ defmodule VintageNet.InterfacesMonitor.Info do
   @link_if_properties [:lower_up, :mac_address]
   @address_if_properties [:addresses]
 
-  @all_if_properties [:present] ++ @link_if_properties ++ @address_if_properties
+  @all_if_properties [:present, :hw_path] ++ @link_if_properties ++ @address_if_properties
 
   defstruct ifname: nil,
+            hw_path: "",
             link: %{},
             addresses: []
 
-  @type t() :: %__MODULE__{ifname: VintageNet.ifname(), link: map(), addresses: [map()]}
+  @type t() :: %__MODULE__{
+          ifname: VintageNet.ifname(),
+          hw_path: String.t(),
+          link: map(),
+          addresses: [map()]
+        }
 
   @doc """
   Create a new struct for caching interface notifications
   """
-  @spec new(VintageNet.ifname()) :: t()
-  def new(ifname) do
-    %__MODULE__{ifname: ifname}
+  @spec new(VintageNet.ifname(), String.t()) :: t()
+  def new(ifname, hw_path \\ "") do
+    %__MODULE__{ifname: ifname, hw_path: hw_path}
   end
 
   @doc """
@@ -146,6 +152,7 @@ defmodule VintageNet.InterfacesMonitor.Info do
   @spec update_present(t()) :: t()
   def update_present(%__MODULE__{ifname: ifname} = info) do
     PropertyTable.put(VintageNet, ["interface", ifname, "present"], true)
+    PropertyTable.put(VintageNet, ["interface", ifname, "hw_path"], info.hw_path)
     info
   end
 

--- a/test/vintage_net/interfaces_monitor/hw_path_test.exs
+++ b/test/vintage_net/interfaces_monitor/hw_path_test.exs
@@ -1,0 +1,32 @@
+defmodule VintageNet.InterfacesMonitor.HWPathTest do
+  use ExUnit.Case
+  doctest VintageNet.InterfacesMonitor.HWPath
+  alias VintageNet.InterfacesMonitor.HWPath
+
+  test "normalizes path" do
+    assert "/devices/pci0000:00/0000:00:01.1/0000:01:00.2/0000:02:04.0/0000:04:00.0" ==
+             HWPath.symlink_to_hw_path(
+               "../../devices/pci0000:00/0000:00:01.1/0000:01:00.2/0000:02:04.0/0000:04:00.0/net/enp4s0",
+               "enp4s0"
+             )
+
+    assert "/devices/virtual" ==
+             HWPath.symlink_to_hw_path("../../devices/virtual/net/lo", "lo")
+
+    assert "/devices/platform/scb/fd580000.genet" ==
+             HWPath.symlink_to_hw_path(
+               "../../devices/platform/scb/fd580000.genet/net/eth0",
+               "eth0"
+             )
+
+    assert "/devices/platform/soc/fe300000.mmcnr/mmc_host/mmc1/mmc1:0001/mmc1:0001:1" ==
+             HWPath.symlink_to_hw_path(
+               "../../devices/platform/soc/fe300000.mmcnr/mmc_host/mmc1/mmc1:0001/mmc1:0001:1/net/wlan0",
+               "wlan0"
+             )
+  end
+
+  test "returns input if unexpected" do
+    assert "/unexpected" == HWPath.symlink_to_hw_path("/unexpected", "enp4s0")
+  end
+end


### PR DESCRIPTION
This adds a way to see how network interfaces are connected internally.
It will be useful when `vintage_net` supports deterministic interface
naming.

Here's an example run on a device with several network interfaces:

```
iex(2)> VintageNet.match(["interface", :_, "hw_path"])
[
  {["interface", "eth0", "hw_path"], "/devices/platform/ocp/4a100000.ethernet"},
  {["interface", "lo", "hw_path"], "/devices/virtual"},
  {["interface", "ppp0", "hw_path"], "/devices/virtual"},
  {["interface", "wlan0", "hw_path"], "/devices/platform/ocp/47400000.usb/47401c00.usb/musb-hdrc.1/usb2/2-1/2-1:1.0"},
  {["interface", "wwan0", "hw_path"], "/devices/platform/ocp/47400000.usb/47401400.usb/musb-hdrc.0/usb1/1-1/1-1:1.4"}
]
```