### PR TITLE
Fix incorrect module name in interface renamer

### DIFF
--- a/lib/vintage_net/interface_renamer.ex
+++ b/lib/vintage_net/interface_renamer.ex
@@ -13,7 +13,7 @@ defmodule VintageNet.InterfaceRenamer do
 
   def renamer do
     case Application.get_env(:vintage_net, :interface_renamer) do
-      nil -> InterfaceRenamer.IP
+      nil -> VintageNet.InterfaceRenamer.IP
       module when is_atom(module) -> module
     end
   end


### PR DESCRIPTION
Missed this during manual checking. Sorry!