### PR TITLE
Remove ifupdown since they're no longer used

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -43,8 +43,6 @@ defmodule VintageNet.MixProject do
         tmpdir: "/tmp/vintage_net",
         to_elixir_socket: "comms",
         bin_dnsd: "dnsd",
-        bin_ifup: "ifup",
-        bin_ifdown: "ifdown",
         bin_ifconfig: "ifconfig",
         bin_chat: "chat",
         bin_pppd: "pppd",

--- a/test/support/utils.ex
+++ b/test/support/utils.ex
@@ -8,8 +8,6 @@ defmodule VintageNetTest.Utils do
     |> Keyword.merge(
       bin_chat: "chat",
       bin_dnsd: "dnsd",
-      bin_ifdown: "ifdown",
-      bin_ifup: "ifup",
       bin_ip: "ip",
       bin_killall: "killall",
       bin_mknod: "mknod",

--- a/test/vintage_net_test.exs
+++ b/test/vintage_net_test.exs
@@ -197,8 +197,6 @@ defmodule VintageNetTest do
       opts = Application.get_all_env(:vintage_net) |> prefix_paths(File.cwd!())
 
       File.mkdir!("sbin")
-      File.touch!("sbin/ifup")
-      File.touch!("sbin/ifdown")
       File.touch!("sbin/ip")
       assert :ok == VintageNet.verify_system(opts)
     end)


### PR DESCRIPTION
When we started, we used to use ifupdown since they made some
configuration so easy. However, we haven't used them in a really long
time and it seems unlikely that we'd ever go back.

This comment removes them to avoid giving the false impression that
anyone may need them to use `vintage_net_*`