### PR TITLE
Don't fail completely when PowerManager.init/1 raises

### DIFF
--- a/lib/vintage_net/power_manager.ex
+++ b/lib/vintage_net/power_manager.ex
@@ -97,6 +97,13 @@ defmodule VintageNet.PowerManager do
 
   This is called on start and if the power management GenServer restarts. It
   should not assume that hardware is powered down.
+
+  IMPORTANT: VintageNet assumes that `init/1` runs quickly and succeeds. Errors
+  and exceptions from calling `init/1` are handled by disabling the PowerManager.
+  The reason is that VintageNet has no knowledge on how to recover and disabling
+  a power manager was deemed less bad that having supervision tree failures
+  propagate upwards to terminate VintageNet. Messages are logged if this does
+  happen.
   """
   @callback init(args :: keyword()) :: {:ok, state :: any()}
 


### PR DESCRIPTION
When `PowerManager.init/1` implementations fail, supervision restarts
GenServers like expected. However, `init/1` really isn't supposed to
fail and when it does, it has the effect of propogating failures all the
way up which eventually takes down VintageNet. While this is almost
certainly a programming error, the result is particularly harsh.

To better support debugging this issue, this commit logs the error and
disables the power manager.

The downside to this is that if there's a transient that would have been
fixed by a restart, that no longer happens and perhaps the network won't
work.  While this isn't good, devices that require network connections
to function need to have a "watchdog" that verifies that there's a
network connection anyway. That logic should catch this.