### PR TITLE
Doc update for resetting an interface

### DIFF
--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -302,6 +302,22 @@ VintageNet.deconfigure("wlan0", persist: false)
 To get the old configuration back, you have to call `VintageNet.configure/3`
 with it again (or restart `VintageNet` or reboot).
 
+### Reset an interface
+
+To reset an interface and maintain subscriptions, the following can be used:
+```elixir
+ifname = "eth0"
+cfg = VintageNet.get_configuration(ifname)
+:ok = VintageNet.deconfigure(ifname, persist: false)
+:ok = VintageNet.Interface.wait_until_configured(ifname, persist: false)
+:ok = VintageNet.configure(ifname, cfg)
+```
+This command is also useful for removing an interface's IP address and routes,
+similar to `ip addr flush dev <ifname>`.
+`VintageNet.Interface.wait_until_configured` is critical to avoid race conditions.
+The `persist: false` option is avoid an issue in the case where the system
+dies before the configure call completes.
+
 ### Perform some initialization to turn on a network interface
 
 `VintageNet` waits for network interfaces to appear before doing any work.  If


### PR DESCRIPTION
I have a use case where I needed to purge network addresses and routes from an interface on cable removal, while ensuring that it is ready to be reconfigured once the cable is reinserted. I was tripped up by a race condition from doing `deconfigure` and then `configure` immediately afterwards. I figure this could be helpful for others looking for how to reset an interface.

If this is useful as a standalone method, I'd be happy to add that too.   