### PR TITLE
Redact :sae_password if present

### DIFF
--- a/lib/vintage_net/info.ex
+++ b/lib/vintage_net/info.ex
@@ -109,7 +109,8 @@ defmodule VintageNet.Info do
   defp sanitize_configuration({key, _})
        when key in [
               :psk,
-              :password
+              :password,
+              :sae_password
             ] do
     {key, "...."}
   end


### PR DESCRIPTION
VintageNetWiFi configs can reference an SAE-specific password, so redact
it if it exists.
