### PR TITLE
Run udhcpc only when the network is up

### DIFF
--- a/lib/vintage_net/interface/ifup_daemon.ex
+++ b/lib/vintage_net/interface/ifup_daemon.ex
@@ -1,0 +1,111 @@
+defmodule VintageNet.Interface.IfupDaemon do
+  use GenServer
+  require Logger
+
+  @moduledoc """
+  Wrap MuonTrap.Daemon to start and stop a program based on whether the network is up
+
+  Unlike MuonTrap.Daemon, the arguments are called out in the child_spec so it looks like
+  this:
+
+  ```
+  {VintageNet.Interface.IfupDaemon, ifname: ifname, command: program, args: arguments, opts: options]}
+  ```
+  """
+
+  @typedoc false
+  @type init_args :: [
+          ifname: VintageNet.ifname(),
+          command: binary(),
+          args: [binary()],
+          opts: keyword()
+        ]
+
+  @enforce_keys [:ifname, :command, :args]
+  defstruct [:ifname, :command, :args, :opts, :pid]
+
+  @doc """
+  Start the IfupDaemon
+  """
+  @spec start_link(init_args()) :: GenServer.on_start()
+  def start_link(init_args) do
+    GenServer.start_link(__MODULE__, init_args)
+  end
+
+  @doc """
+  Return whether the daemon is running
+  """
+  @spec running?(GenServer.server()) :: boolean()
+  def running?(server) do
+    GenServer.call(server, :running?)
+  end
+
+  @impl GenServer
+  def init(init_args) do
+    state = struct!(__MODULE__, init_args)
+    {:ok, state, {:continue, :continue}}
+  end
+
+  @impl GenServer
+  def handle_continue(:continue, %{ifname: ifname} = state) do
+    VintageNet.subscribe(lower_up_property(ifname))
+
+    new_state =
+      case VintageNet.get(lower_up_property(ifname)) do
+        true ->
+          start_daemon(state)
+
+        _not_true ->
+          # If the physical layer isn't up, don't start until
+          # we're notified that it is available.
+          state
+      end
+
+    {:noreply, new_state}
+  end
+
+  @impl GenServer
+  def handle_call(:running?, _from, state) do
+    {:reply, state.pid != nil and Process.alive?(state.pid), state}
+  end
+
+  @impl GenServer
+  def handle_info(
+        {VintageNet, ["interface", ifname, "lower_up"], _old_value, true, _meta},
+        %{ifname: ifname} = state
+      ) do
+    # Physical layer is up. Optimistically assume that the LAN is accessible.
+    {:noreply, start_daemon(state)}
+  end
+
+  def handle_info(
+        {VintageNet, ["interface", ifname, "lower_up"], _old_value, _false_or_nil, _meta},
+        %{ifname: ifname} = state
+      ) do
+    # Physical layer is down or disconnected. We're definitely disconnected.
+    {:noreply, stop_daemon(state)}
+  end
+
+  defp start_daemon(%{pid: nil} = state) do
+    Logger.debug("[vintage_net(#{state.ifname})] starting #{state.command}")
+
+    {:ok, pid} = MuonTrap.Daemon.start_link(state.command, state.args, state.opts)
+    %{state | pid: pid}
+  end
+
+  defp start_daemon(state), do: state
+
+  defp stop_daemon(%{pid: pid} = state) when is_pid(pid) do
+    Logger.debug("[vintage_net(#{state.ifname})] stopping #{state.command}")
+
+    if Process.alive?(pid), do: GenServer.stop(pid)
+
+    %{state | pid: nil}
+  end
+
+  defp stop_daemon(state), do: state
+
+  defp lower_up_property(ifname) do
+    ["interface", ifname, "lower_up"]
+  end
+end

--- a/lib/vintage_net/ip/ipv4_config.ex
+++ b/lib/vintage_net/ip/ipv4_config.ex
@@ -156,10 +156,11 @@ defmodule VintageNet.IP.IPv4Config do
       child_specs ++
         [
           Supervisor.child_spec(
-            {MuonTrap.Daemon,
+            {VintageNet.Interface.IfupDaemon,
              [
-               "udhcpc",
-               [
+               ifname: ifname,
+               command: "udhcpc",
+               args: [
                  "-f",
                  "-i",
                  ifname,
@@ -168,12 +169,13 @@ defmodule VintageNet.IP.IPv4Config do
                  "-s",
                  BEAMNotify.bin_path()
                ],
-               Command.add_muon_options(
-                 stderr_to_stdout: true,
-                 log_output: :debug,
-                 log_prefix: "udhcpc(#{ifname}): ",
-                 env: BEAMNotify.env(name: "vintage_net_comm", report_env: true)
-               )
+               opts:
+                 Command.add_muon_options(
+                   stderr_to_stdout: true,
+                   log_output: :debug,
+                   log_prefix: "udhcpc(#{ifname}): ",
+                   env: BEAMNotify.env(name: "vintage_net_comm", report_env: true)
+                 )
              ]},
             id: :udhcpc
           ),

--- a/test/support/utils.ex
+++ b/test/support/utils.ex
@@ -10,29 +10,29 @@ defmodule VintageNetTest.Utils do
   def udhcpc_child_spec(ifname, hostname) do
     %{
       id: :udhcpc,
-      restart: :permanent,
-      shutdown: 500,
       start:
-        {MuonTrap.Daemon, :start_link,
+        {VintageNet.Interface.IfupDaemon, :start_link,
          [
-           "udhcpc",
            [
-             "-f",
-             "-i",
-             ifname,
-             "-x",
-             "hostname:#{hostname}",
-             "-s",
-             BEAMNotify.bin_path()
-           ],
-           [
-             stderr_to_stdout: true,
-             log_output: :debug,
-             log_prefix: "udhcpc(#{ifname}): ",
-             env: BEAMNotify.env(name: "vintage_net_comm", report_env: true)
+             ifname: ifname,
+             command: "udhcpc",
+             args: [
+               "-f",
+               "-i",
+               ifname,
+               "-x",
+               "hostname:#{hostname}",
+               "-s",
+               BEAMNotify.bin_path()
+             ],
+             opts: [
+               stderr_to_stdout: true,
+               log_output: :debug,
+               log_prefix: "udhcpc(#{ifname}): ",
+               env: BEAMNotify.env(name: "vintage_net_comm", report_env: true)
+             ]
            ]
-         ]},
-      type: :worker
+         ]}
     }
   end
 


### PR DESCRIPTION
This adds a helper GenServer to let you run OS processes only when a
network interface is up, and then uses it to run udhcpc. It fixes a few
annoyances:

1. No more udhcpc prints when it can't get an IP address when an
   Ethernet cable isn't plugged in
2. No more waiting for udhcpc to retry to get an IP address when
   plugging in an Ethernet cable.

It feels like the system connects to the network faster.
