### PR TITLE
Lack of IPv4 doesn't mean disconnected

### DIFF
--- a/lib/vintage_net/interface/internet_connectivity_checker.ex
+++ b/lib/vintage_net/interface/internet_connectivity_checker.ex
@@ -106,7 +106,7 @@ defmodule VintageNet.Interface.InternetConnectivityChecker do
           {:disconnected, @max_fails_in_a_row}
 
         {:error, :no_ipv4_address} ->
-          {:disconnected, @max_fails_in_a_row}
+          {:lan, @max_fails_in_a_row}
 
         {:error, reason} ->
           if strikes < @max_fails_in_a_row do


### PR DESCRIPTION
The Internet connectivity checker would declare that the network was
disconnected if an IPv4 address wasn't available. This is untrue for a
couple reasons:

1. IPv6 addresses are available
2. DHCP and layer 2 protocols could still be used

This also had a weird side effect where interfaces would initially come
up (`lan` connectivity), then go disconnected when an IPv4 address
wasn't found, and then come back when an IPv4 address was found.

Fixes #268
