### PR TITLE
Allow get_configuration to return a default value

### DIFF
--- a/lib/vintage_net.ex
+++ b/lib/vintage_net.ex
@@ -148,9 +148,21 @@ defmodule VintageNet do
 
   @doc """
   Return the settings for the specified interface
+
+  If the configuration does not exist return the `default` value.
   """
-  @spec get_configuration(ifname()) :: map()
-  def get_configuration(ifname) do
+  @spec get_configuration(ifname(), default :: any()) :: map() | any()
+  def get_configuration(ifname, default \\ nil) do
+    PropertyTable.get(VintageNet, ["interface", ifname, "config"], default)
+  end
+
+  @doc """
+  Return the settings for the specified interface
+
+  If the configuration does not exist this will raise a `RuntimeError`.
+  """
+  @spec get_configuration!(ifname()) :: map()
+  def get_configuration!(ifname) do
     PropertyTable.get(VintageNet, ["interface", ifname, "config"]) ||
       raise RuntimeError, "No configuration for #{ifname}"
   end

--- a/test/vintage_net_test.exs
+++ b/test/vintage_net_test.exs
@@ -156,6 +156,17 @@ defmodule VintageNetTest do
            }
   end
 
+  test "get configuration that does exist returns default value" do
+    assert nil == VintageNet.get_configuration("does not exist")
+    assert %{} == VintageNet.get_configuration("does not exist", %{})
+  end
+
+  test "get_configuration! raises a runtime error when the configuration does not exist" do
+    assert_raise RuntimeError, ~r/^No configuration for \w+/, fn ->
+      VintageNet.get_configuration!("does not exist")
+    end
+  end
+
   # Check that get, get_by_prefix, and match are available in the public
   # interface. Better tests should be else.
   test "get" do


### PR DESCRIPTION
Sometimes when changing to different network interfaces some systems
may or may not have a configuration for the either the new interface or
the old one. Changing `get_configuration` to return a default value (or
nil by default) will allow users to check if a configuration exists or
not for the interface.

Also, providing the `get_configuration!` function keeps the current
behavior in the library.

The reason to need this over `configured_interfaces/1` is because that
function considers configurations with `VintageNet.Technology.Null` to
not be configured and will be filtered out.