### PR TITLE
Check more than one IP address for Internet connectivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ resolvconf         | Path to `/etc/resolv.conf`
 persistence        | Module for persisting network configurations
 persistence_dir    | Path to a directory for storing persisted configurations
 persistence_secret | A 16-byte secret or an MFA for getting a secret
-internet_host      | IP address for host to `ping` to check for Internet connectivity. Must be a tuple of integers (`{1, 1, 1, 1}`) or binary representation (`"1.1.1.1"`)
+internet_host_list | IP address/ports to try to connect to for checking Internet connectivity. Defaults to a list of large public DNS providers. E.g., `[{{1, 1, 1, 1}, 53}]`.
 regulatory_domain  | ISO 3166-1 alpha-2 country (`00` for global, `US`, etc.)
 
 ## Network interface configuration

--- a/lib/vintage_net/interface/internet_connectivity_checker.ex
+++ b/lib/vintage_net/interface/internet_connectivity_checker.ex
@@ -2,7 +2,7 @@ defmodule VintageNet.Interface.InternetConnectivityChecker do
   use GenServer
   require Logger
 
-  alias VintageNet.Interface.InternetTester
+  alias VintageNet.Interface.{Classification, InternetTester}
   alias VintageNet.{PropertyTable, RouteManager}
 
   @moduledoc """
@@ -17,6 +17,14 @@ defmodule VintageNet.Interface.InternetConnectivityChecker do
   @max_interval 30_000
   @max_fails_in_a_row 3
 
+  @typep state() :: %{
+           ifname: VintageNet.ifname(),
+           hosts: [{VintageNet.any_ip_address(), non_neg_integer()}],
+           strikes: non_neg_integer(),
+           interval: non_neg_integer(),
+           connectivity: Classification.connection_status()
+         }
+
   @doc """
   Start the connectivity checker GenServer
   """
@@ -27,14 +35,20 @@ defmodule VintageNet.Interface.InternetConnectivityChecker do
 
   @impl GenServer
   def init(ifname) do
-    # Handle GenServer restarts when internet-connected
-    initial_strikes =
-      case VintageNet.get(["interface", ifname, "connection"]) do
-        :internet -> 0
-        _ -> @max_fails_in_a_row
-      end
+    # Handle GenServer restarts when internet-connected. If internet connected,
+    # then start the strike count over at zero since who knows where things were
+    # at and that way a first strike doesn't bounce the status.
+    connectivity = VintageNet.get(["interface", ifname, "connection"])
+    initial_strikes = if connectivity == :internet, do: 0, else: @max_fails_in_a_row
 
-    state = %{ifname: ifname, strikes: initial_strikes, interval: @min_interval}
+    state = %{
+      ifname: ifname,
+      hosts: get_internet_host_list(),
+      strikes: initial_strikes,
+      interval: @min_interval,
+      connectivity: connectivity
+    }
+
     {:ok, state, {:continue, :continue}}
   end
 
@@ -42,18 +56,14 @@ defmodule VintageNet.Interface.InternetConnectivityChecker do
   def handle_continue(:continue, %{ifname: ifname} = state) do
     VintageNet.subscribe(lower_up_property(ifname))
 
-    case VintageNet.get(lower_up_property(ifname)) do
-      true ->
-        new_state = check_connectivity(state)
+    new_state =
+      if VintageNet.get(lower_up_property(ifname)) do
+        check_connectivity(state)
+      else
+        state |> ifdown() |> report_connectivity()
+      end
 
-        {:noreply, new_state, new_state.interval}
-
-      _not_true ->
-        # If the physical layer isn't up, don't start polling until
-        # we're notified that it is available.
-        set_connectivity(ifname, :disconnected)
-        {:noreply, state}
-    end
+    {:noreply, new_state, new_state.interval}
   end
 
   @impl GenServer
@@ -67,92 +77,176 @@ defmodule VintageNet.Interface.InternetConnectivityChecker do
         {VintageNet, ["interface", ifname, "lower_up"], _old_value, false, _meta},
         %{ifname: ifname} = state
       ) do
-    # Physical layer is down. We're definitely disconnected, so skip right to it and
-    # don't poll until the lower_up changes
-    set_connectivity(ifname, :disconnected)
-    {:noreply, state}
+    new_state = state |> ifdown() |> report_connectivity()
+
+    {:noreply, new_state}
   end
 
   def handle_info(
         {VintageNet, ["interface", ifname, "lower_up"], _old_value, true, _meta},
         %{ifname: ifname} = state
       ) do
-    # Physical layer is up. Optimistically assume that the LAN is accessible and
-    # start polling again after a short delay
-    set_connectivity(ifname, :lan)
+    new_state = state |> ifup() |> report_connectivity()
 
-    new_state = %{state | interval: @min_interval}
     {:noreply, new_state, @min_interval}
   end
 
   def handle_info(
-        {VintageNet, ["interface", ifname, "lower_up"], old_value, nil, _meta},
+        {VintageNet, ["interface", ifname, "lower_up"], _old_value, nil, _meta},
         %{ifname: ifname} = state
       ) do
     # The interface was completely removed!
-    if old_value, do: set_connectivity(ifname, :disconnected)
-    {:noreply, state}
+    new_state = state |> ifdown() |> report_connectivity()
+    {:noreply, new_state}
   end
 
-  defp check_connectivity(%{ifname: ifname, strikes: strikes, interval: interval} = state) do
-    {connectivity, new_strikes} =
-      case InternetTester.ping(ifname) do
-        :ok ->
-          # Success - reset the number of strikes to stay in Internet mode
-          # even if there are hiccups.
-          {:internet, 0}
-
-        {:error, :if_not_found} ->
-          {:disconnected, @max_fails_in_a_row}
-
-        {:error, :no_ipv4_address} ->
-          {:lan, @max_fails_in_a_row}
-
-        {:error, reason} ->
-          if strikes < @max_fails_in_a_row do
-            Logger.debug(
-              "#{ifname}: Internet test failed (#{inspect(reason)}: #{strikes + 1}/#{
-                @max_fails_in_a_row
-              } strikes"
-            )
-
-            {:internet, strikes + 1}
-          else
-            Logger.debug("#{ifname}: Internet test failed: (#{inspect(reason)})")
-            {:lan, @max_fails_in_a_row}
-          end
-      end
-
-    new_state = %{
-      state
-      | strikes: new_strikes,
-        interval: next_interval(connectivity, interval, strikes)
-    }
-
-    set_connectivity(ifname, connectivity)
-
-    new_state
+  defp ifdown(state) do
+    # Physical layer is down. Don't poll for connectivity since it won't happen.
+    %{state | connectivity: :disconnected, interval: :infinity}
   end
 
-  defp set_connectivity(ifname, connectivity) do
+  defp ifup(state) do
+    # Physical layer is up. Optimistically assume that the LAN is accessible and
+    # start polling again after a short delay
+    %{state | connectivity: :lan, interval: @min_interval}
+  end
+
+  defp check_connectivity(state) do
+    ping_result = InternetTester.ping(state.ifname, hd(state.hosts))
+
+    state
+    |> update_state_from_ping(ping_result)
+    |> report_connectivity()
+    |> compute_next_interval()
+  end
+
+  # Public for unit test purposes
+  @doc false
+  @spec update_state_from_ping(state(), :ok | {:error, InternetTester.ping_error_reason()}) ::
+          state()
+  def update_state_from_ping(state, :ok) do
+    # Success - reset the number of strikes to stay in Internet mode
+    # even if there are hiccups.
+    %{state | connectivity: :internet, strikes: 0}
+  end
+
+  def update_state_from_ping(state, {:error, :if_not_found}) do
+    %{state | connectivity: :disconnected, strikes: @max_fails_in_a_row}
+  end
+
+  def update_state_from_ping(state, {:error, :no_ipv4_address}) do
+    %{state | connectivity: :lan, strikes: @max_fails_in_a_row}
+  end
+
+  def update_state_from_ping(%{connectivity: :internet} = state, {:error, reason}) do
+    strikes = state.strikes + 1
+
+    if strikes < @max_fails_in_a_row do
+      Logger.debug(
+        "#{state.ifname}: Internet check failed to #{inspect(hd(state.hosts))} (#{inspect(reason)}): #{
+          strikes
+        }/#{@max_fails_in_a_row} strikes"
+      )
+
+      %{state | connectivity: :internet, strikes: strikes, hosts: rotate_list(state.hosts)}
+    else
+      Logger.debug("#{state.ifname}: Internet unreachable: (#{inspect(reason)})")
+      %{state | connectivity: :lan, strikes: @max_fails_in_a_row}
+    end
+  end
+
+  def update_state_from_ping(state, {:error, _reason}) do
+    # Final case where the internet wasn't reachable and it wasn't reachable before this.
+    # Rotate the hosts to check and maybe we'll get lucky next time.
+    %{state | hosts: rotate_list(state.hosts)}
+  end
+
+  defp report_connectivity(%{ifname: ifname, connectivity: connectivity} = state) do
+    # It's desirable to set these even if redundant since the checks in this
+    # modules are authoritative. I.e., the internet isn't connected unless we
+    # declare it detected. Other modules can reset the connection to :lan
+    # if, for example, a new IP address gets set by DHCP. The following functions
+    # will optimize out redundant calls if they really are redundant.
     RouteManager.set_connection_status(ifname, connectivity)
     PropertyTable.put(VintageNet, ["interface", ifname, "connection"], connectivity)
+    state
   end
 
   defp lower_up_property(ifname) do
     ["interface", ifname, "lower_up"]
   end
 
+  # Public for unit test purposes
+  @doc false
+  @spec compute_next_interval(state()) :: state()
+  def compute_next_interval(state) do
+    %{state | interval: next_interval(state.connectivity, state.interval, state.strikes)}
+  end
+
+  # Public for unit test purposes
+  @doc false
+  @spec next_interval(Classification.connection_status(), non_neg_integer(), non_neg_integer()) ::
+          non_neg_integer()
+  def next_interval(connection, interval, strikes)
+
   # If pings work, then wait the max interval before checking again
-  defp next_interval(:internet, _interval, 0), do: @max_interval
+  def next_interval(:internet, _interval, 0), do: @max_interval
 
   # If a ping fails, retry, but don't wait as long as when everything is working
-  defp next_interval(:internet, _interval, strikes) do
+  def next_interval(:internet, _interval, strikes) do
     max(@min_interval, div(@max_interval, strikes + 1))
   end
 
   # Back off of checks if they're not working
-  defp next_interval(_not_internet, interval, _strikes) do
+  def next_interval(:lan, interval, _strikes) do
     min(interval * 2, @max_interval)
+  end
+
+  # Wait for interface up notification before polling again
+  def next_interval(:disconnected, _interval, _strikes), do: :infinity
+
+  # Rotate a list left
+  @doc false
+  @spec rotate_list(list()) :: list()
+  def rotate_list([]), do: []
+  def rotate_list(hosts), do: tl(hosts) ++ [hd(hosts)]
+
+  defp get_internet_host_list() do
+    hosts = legacy_internet_host() ++ Application.get_env(:vintage_net, :internet_host_list)
+    good_hosts = Enum.flat_map(hosts, &normalize_internet_host/1)
+
+    if good_hosts == [] do
+      Logger.warn("VintageNet: `:internet_host_list` is invalid. Using defaults")
+      [{1, 1, 1, 1}, 80]
+    else
+      good_hosts
+    end
+  end
+
+  defp legacy_internet_host() do
+    case Application.get_env(:vintage_net, :internet_host) do
+      nil ->
+        []
+
+      host ->
+        Logger.warn(
+          "VintageNet: Legacy :internet_host key is in use. Please change this to `internet_host_list: [{#{
+            inspect(host)
+          }, 80}]."
+        )
+
+        [{host, 80}]
+    end
+  end
+
+  defp normalize_internet_host({host, port}) when port > 0 and port < 65536 do
+    case VintageNet.IP.ip_to_tuple(host) do
+      {:ok, host_as_tuple} -> [{host_as_tuple, port}]
+      _anything_else -> []
+    end
+  end
+
+  defp normalize_internet_host(other) do
+    Logger.warn("VintageNet: Dropping invalid Internet destination (#{inspect(other)})")
   end
 end

--- a/lib/vintage_net/interface/internet_tester.ex
+++ b/lib/vintage_net/interface/internet_tester.ex
@@ -5,32 +5,30 @@ defmodule VintageNet.Interface.InternetTester do
   See the InternetConnectivityChecker for a GenServer that checks on regular
   intervals and updates VintageNet properties as needed.
   """
-  @ping_port 80
   @ping_timeout 5_000
 
   @type ping_error_reason :: :if_not_found | :no_ipv4_address | :inet.posix()
 
   @doc """
-  This "ping"'s a server on the Internet that has a good chance being available
+  Check connectivity with another device
 
-  The "ping" is really a TCP connection attempt from the specified interface.
-  Failures to connect don't necessarily mean that the Internet is down, but it's
-  likely especially if the server that's specified in the configuration is
-  highly available.
+  The "ping" is really a TCP connection attempt from the specified interface to
+  an IP address and port. Failures to connect don't necessarily mean that the
+  Internet is down, but it's likely especially if the server that's specified
+  in the configuration is highly available.
 
   Source IP-based routing is required for the TCP connect to go out the right
   network interface. This is configured by default when using VintageNet.
   """
-  @spec ping(VintageNet.ifname()) :: :ok | {:error, ping_error_reason()}
-  def ping(ifname) do
-    internet_host = Application.get_env(:vintage_net, :internet_host)
-
+  @spec ping(VintageNet.ifname(), {VintageNet.any_ip_address(), non_neg_integer()}) ::
+          :ok | {:error, ping_error_reason()}
+  def ping(ifname, {host, port}) do
     with {:ok, src_ip} <- get_interface_address(ifname),
          # Note: No support for DNS since DNS can't be forced through
          # an interface. I.e., errors on other interfaces mess up DNS
          # even if the one of interest is ok.
-         {:ok, dest_ip} <- VintageNet.IP.ip_to_tuple(internet_host),
-         {:ok, tcp} <- :gen_tcp.connect(dest_ip, @ping_port, [ip: src_ip], @ping_timeout) do
+         {:ok, dest_ip} <- VintageNet.IP.ip_to_tuple(host),
+         {:ok, tcp} <- :gen_tcp.connect(dest_ip, port, [ip: src_ip], @ping_timeout) do
       _ = :gen_tcp.close(tcp)
       :ok
     else

--- a/lib/vintage_net/interface/internet_tester.ex
+++ b/lib/vintage_net/interface/internet_tester.ex
@@ -32,8 +32,16 @@ defmodule VintageNet.Interface.InternetTester do
       _ = :gen_tcp.close(tcp)
       :ok
     else
-      {:error, reason} -> {:error, reason}
-      posix_error -> {:error, posix_error}
+      {:error, :econnrefused} ->
+        # If the remote refuses the connection, then that means that it received it
+        # and we're connected to the internet!
+        :ok
+
+      {:error, reason} ->
+        {:error, reason}
+
+      posix_error ->
+        {:error, posix_error}
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -46,8 +46,20 @@ defmodule VintageNet.MixProject do
         persistence: VintageNet.Persistence.FlatFile,
         persistence_dir: "/root/vintage_net",
         persistence_secret: "obfuscate_things",
-        internet_host_list: [{{1, 1, 1, 1}, 80}],
-        internet_host: nil,
+        # List of reliable hosts used to check Internet connectivity
+        # Use IP addresses and port numbers here rather than names.
+        internet_host_list: [
+          # Cloudflare DNS over TCP
+          {{1, 1, 1, 1}, 53},
+          # Google public DNS over TCP
+          {{8, 8, 8, 8}, 53},
+          # OpenDNS
+          {{208, 67, 222, 222}, 53},
+          # Quad9
+          {{9, 9, 9, 9}, 53},
+          # Neustar
+          {{156, 154, 70, 5}, 53}
+        ],
         regulatory_domain: "00",
         # Contain processes in cgroups by setting to:
         #   [cgroup_base: "vintage_net", cgroup_controllers: ["cpu"]]

--- a/mix.exs
+++ b/mix.exs
@@ -46,7 +46,8 @@ defmodule VintageNet.MixProject do
         persistence: VintageNet.Persistence.FlatFile,
         persistence_dir: "/root/vintage_net",
         persistence_secret: "obfuscate_things",
-        internet_host: {1, 1, 1, 1},
+        internet_host_list: [{{1, 1, 1, 1}, 80}],
+        internet_host: nil,
         regulatory_domain: "00",
         # Contain processes in cgroups by setting to:
         #   [cgroup_base: "vintage_net", cgroup_controllers: ["cpu"]]

--- a/test/vintage_net/interface/internet_connectivity_checker_test.exs
+++ b/test/vintage_net/interface/internet_connectivity_checker_test.exs
@@ -3,6 +3,111 @@ defmodule VintageNet.Interface.InternetConnectivityCheckerTest do
 
   alias VintageNet.Interface.InternetConnectivityChecker
 
+  describe "update_state_from_ping/2" do
+    test "internet scenarios" do
+      base_state = %{ifname: "bogus0", connectivity: :internet, strikes: 0, hosts: [1, 2]}
+
+      # Ping worked -> good internet
+      assert InternetConnectivityChecker.update_state_from_ping(base_state, :ok) ==
+               %{ifname: "bogus0", connectivity: :internet, hosts: [1, 2], strikes: 0}
+
+      # Ping failed once -> rotate hosts and add a strike
+      assert InternetConnectivityChecker.update_state_from_ping(
+               base_state,
+               {:error, :ehostdown}
+             ) ==
+               %{ifname: "bogus0", connectivity: :internet, hosts: [2, 1], strikes: 1}
+
+      # No IP address reverts to LAN
+      assert InternetConnectivityChecker.update_state_from_ping(
+               base_state,
+               {:error, :no_ipv4_address}
+             ) ==
+               %{ifname: "bogus0", connectivity: :lan, hosts: [1, 2], strikes: 3}
+
+      # No interfaces goes to disconnected
+      assert InternetConnectivityChecker.update_state_from_ping(
+               base_state,
+               {:error, :if_not_found}
+             ) ==
+               %{ifname: "bogus0", connectivity: :disconnected, hosts: [1, 2], strikes: 3}
+
+      # Check 3 strikes reverts to :lan
+      base_state = %{ifname: "bogus0", connectivity: :internet, strikes: 2, hosts: [1, 2]}
+
+      assert InternetConnectivityChecker.update_state_from_ping(
+               base_state,
+               {:error, :ehostdown}
+             ) ==
+               %{ifname: "bogus0", connectivity: :lan, hosts: [1, 2], strikes: 3}
+    end
+
+    test "lan scenarios" do
+      base_state = %{ifname: "bogus0", connectivity: :lan, strikes: 3, hosts: [1, 2]}
+
+      # No response. Host order should rotate
+      assert InternetConnectivityChecker.update_state_from_ping(
+               base_state,
+               {:error, :ehostdown}
+             ) ==
+               %{ifname: "bogus0", connectivity: :lan, hosts: [2, 1], strikes: 3}
+
+      # Response. Should be internet connected now.
+      assert InternetConnectivityChecker.update_state_from_ping(base_state, :ok) ==
+               %{ifname: "bogus0", connectivity: :internet, hosts: [1, 2], strikes: 0}
+
+      # No interfaces goes to disconnected
+      assert InternetConnectivityChecker.update_state_from_ping(
+               base_state,
+               {:error, :if_not_found}
+             ) ==
+               %{ifname: "bogus0", connectivity: :disconnected, hosts: [1, 2], strikes: 3}
+    end
+
+    test "disconnected scenarios" do
+      # This isn't supposed to be called when disconnected, but check that it doesn't
+      # crash.
+      base_state = %{ifname: "bogus0", connectivity: :disconnected, strikes: 3, hosts: [1, 2]}
+
+      # No response -> rotate hosts like when lan connected
+      assert InternetConnectivityChecker.update_state_from_ping(
+               base_state,
+               {:error, :ehostdown}
+             ) ==
+               %{ifname: "bogus0", connectivity: :disconnected, hosts: [2, 1], strikes: 3}
+
+      # Magic internet availability
+      assert InternetConnectivityChecker.update_state_from_ping(base_state, :ok) ==
+               %{ifname: "bogus0", connectivity: :internet, hosts: [1, 2], strikes: 0}
+    end
+  end
+
+  test "next_interval/1" do
+    max_interval = 30_000
+    min_interval = 500
+
+    # Check that internet-connected scenarios retry more aggressively, but never
+    # more frequent than the minimum interval setting
+    assert InternetConnectivityChecker.next_interval(:internet, 1, 0) == max_interval
+    assert InternetConnectivityChecker.next_interval(:internet, 1, 1) == div(max_interval, 2)
+    assert InternetConnectivityChecker.next_interval(:internet, 1, 2) == div(max_interval, 3)
+    assert InternetConnectivityChecker.next_interval(:internet, 1, 1000) == min_interval
+
+    # Check LAN scenarios back off when not working
+    assert InternetConnectivityChecker.next_interval(:lan, 100, 1) == 200
+    assert InternetConnectivityChecker.next_interval(:lan, max_interval, 1) == max_interval
+
+    # Disabled anything has an infinite timeout to avoid needless polls
+    assert InternetConnectivityChecker.next_interval(:disconnected, 100, 1) == :infinity
+  end
+
+  test "rotate_list/1" do
+    assert [1] == InternetConnectivityChecker.rotate_list([1])
+    assert [2, 1] == InternetConnectivityChecker.rotate_list([1, 2])
+    assert [2, 3, 1] == InternetConnectivityChecker.rotate_list([1, 2, 3])
+    assert [] == InternetConnectivityChecker.rotate_list([])
+  end
+
   test "disconnected interface" do
     property = ["interface", "disconnected_interface", "connection"]
     VintageNet.subscribe(property)


### PR DESCRIPTION
This is a series of commits so that VintageNet can check more the one IP address
for internet connectivity. This addresses a rare issue where one location could
be blocked or down temporarily and that would prevent a positive internet
connectivity result.

This also includes an update to add more large public DNS servers to the list
and changes the detection to also succeed if the connection is refused. If the
connection is refused, that also means that the server is available and so is
the internet.

- Support >1 internet host to check; refactor to be easier to test
- Use :econnrefused as proof of internet connectivity
- Add DNS servers to internet connectivity check
