### PR TITLE
Don't include empty search domains in the resolv.conf

### DIFF
--- a/lib/vintage_net/resolver/resolv_conf.ex
+++ b/lib/vintage_net/resolver/resolv_conf.ex
@@ -37,7 +37,7 @@ defmodule VintageNet.Resolver.ResolvConf do
   defp name_server_text({server, ifnames}),
     do: ["nameserver ", IP.ip_to_string(server), " # From ", Enum.join(ifnames, ","), "\n"]
 
-  defp add_domain({ifname, %{domain: domain}}, acc) when not is_nil(domain) do
+  defp add_domain({ifname, %{domain: domain}}, acc) when is_binary(domain) and domain != "" do
     Map.update(acc, domain, [ifname], fn ifnames -> [ifname | ifnames] end)
   end
 

--- a/test/vintage_net/resolver/resolv_conf_test.exs
+++ b/test/vintage_net/resolver/resolv_conf_test.exs
@@ -64,6 +64,21 @@ defmodule VintageNet.Resolver.ResolvConfTest do
     assert to_resolvconf(input) == output
   end
 
+  test "empty search domain" do
+    input = %{
+      "eth0" => %{domain: "", name_servers: [{1, 1, 1, 1}, {8, 8, 8, 8}]}
+    }
+
+    output = """
+    # This file is managed by VintageNet. Do not edit.
+
+    nameserver 1.1.1.1 # From eth0
+    nameserver 8.8.8.8 # From eth0
+    """
+
+    assert to_resolvconf(input) == output
+  end
+
   test "pruning redundant entries" do
     input = %{
       "eth0" => %{domain: "example.com", name_servers: [{1, 1, 1, 1}, {8, 8, 8, 8}]},


### PR DESCRIPTION
An LTE modem gave an empty search domain for some reason. This filters
it out.
