### PR TITLE
 Centralize interface connectivity in the RouteManager

### DIFF
--- a/lib/vintage_net/interface.ex
+++ b/lib/vintage_net/interface.ex
@@ -736,9 +736,9 @@ defmodule VintageNet.Interface do
 
     if state != :configured do
       # Once a state is `:configured`, then the configuration provides the connection
-      # status. When not configured, report it as `:disconnected` to avoid any confusion
-      # with stale or unset values.
-      PropertyTable.put(VintageNet, ["interface", ifname, "connection"], :disconnected)
+      # status. When not configured, make sure there are no routing tables entries or
+      # stale properties.
+      RouteManager.set_connection_status(ifname, :disconnected)
     end
   end
 

--- a/lib/vintage_net/interface/internet_connectivity_checker.ex
+++ b/lib/vintage_net/interface/internet_connectivity_checker.ex
@@ -3,7 +3,7 @@ defmodule VintageNet.Interface.InternetConnectivityChecker do
   require Logger
 
   alias VintageNet.Interface.{Classification, InternetTester}
-  alias VintageNet.{PropertyTable, RouteManager}
+  alias VintageNet.RouteManager
 
   @moduledoc """
   This GenServer monitors a network interface for Internet connectivity
@@ -163,10 +163,9 @@ defmodule VintageNet.Interface.InternetConnectivityChecker do
     # It's desirable to set these even if redundant since the checks in this
     # modules are authoritative. I.e., the internet isn't connected unless we
     # declare it detected. Other modules can reset the connection to :lan
-    # if, for example, a new IP address gets set by DHCP. The following functions
-    # will optimize out redundant calls if they really are redundant.
+    # if, for example, a new IP address gets set by DHCP. The following call
+    # will optimize out redundant updates if they really are redundant.
     RouteManager.set_connection_status(ifname, connectivity)
-    PropertyTable.put(VintageNet, ["interface", ifname, "connection"], connectivity)
     state
   end
 

--- a/lib/vintage_net/route/properties.ex
+++ b/lib/vintage_net/route/properties.ex
@@ -57,4 +57,14 @@ defmodule VintageNet.Route.Properties do
     for {:local_route, ifname, _address, _subnet_bits, metric, :main} <- routes,
         do: {metric, ifname}
   end
+
+  @doc """
+  Update the every interface's connection status
+  """
+  @spec update_connection_status(Calculator.interface_infos()) :: :ok
+  def update_connection_status(infos) do
+    Enum.each(infos, fn {ifname, %{status: status}} ->
+      VintageNet.PropertyTable.put(VintageNet, ["interface", ifname, "connection"], status)
+    end)
+  end
 end

--- a/test/vintage_net/route/properties_test.exs
+++ b/test/vintage_net/route/properties_test.exs
@@ -81,4 +81,44 @@ defmodule VintageNet.Route.PropertiesTest do
       assert status == VintageNet.get(["connection"])
     end
   end
+
+  test "updates connection status" do
+    interfaces = %{
+      "eth0" => %InterfaceInfo{
+        interface_type: :ethernet,
+        status: :lan,
+        weight: 0,
+        ip_subnets: [{{192, 168, 1, 50}, 24}],
+        default_gateway: {192, 168, 1, 1}
+      },
+      "wlan0" => %InterfaceInfo{
+        interface_type: :wifi,
+        status: :internet,
+        weight: 0,
+        ip_subnets: [{{192, 168, 1, 60}, 24}],
+        default_gateway: {192, 168, 1, 1}
+      },
+      "usb0" => %InterfaceInfo{
+        interface_type: :local,
+        status: :disconnected,
+        weight: 0,
+        ip_subnets: [{{192, 168, 1, 70}, 24}],
+        default_gateway: {192, 168, 1, 1}
+      },
+      "wwan0" => %InterfaceInfo{
+        interface_type: :mobile,
+        status: :internet,
+        weight: 0,
+        ip_subnets: [{{192, 168, 1, 70}, 24}],
+        default_gateway: {192, 168, 1, 1}
+      }
+    }
+
+    :ok = Properties.update_connection_status(interfaces)
+
+    assert :lan == VintageNet.get(["interface", "eth0", "connection"])
+    assert :internet == VintageNet.get(["interface", "wlan0", "connection"])
+    assert :disconnected == VintageNet.get(["interface", "usb0", "connection"])
+    assert :internet == VintageNet.get(["interface", "wwan0", "connection"])
+  end
 end

--- a/test/vintage_net_test.exs
+++ b/test/vintage_net_test.exs
@@ -50,6 +50,9 @@ defmodule VintageNetTest do
       ])
 
       Application.start(:vintage_net)
+
+      # Loading of configurations is async and sometimes fails without short sleep
+      Process.sleep(10)
     end)
 
     # Restore the configuration and persistance state to the original way


### PR DESCRIPTION
Network interfaces can be disconnected, lan-connected or
internet-connected. This information was managed both in the
RouteManager and in the internet connectivity checkers. This moves 
management to the RouteManager. The logic is:

1. The RouteManager has the final say, since it controls the routing
   tables.
2. The RouteManager publishes the summary properties that say what the
   active interface is and whether the device as a whole is
   internet-connected, lan-connected, or disconnected. It was possible
   for the RouteManager to think that the device as a whole was lan-
   connected when it really was internet-connected. Managing this in
   one place removes the bug.

