### PR TITLE
Filter out invalid configs

### DIFF
--- a/test/vintage_net_test.exs
+++ b/test/vintage_net_test.exs
@@ -30,7 +30,8 @@ defmodule VintageNetTest do
          %{
            type: VintageNetTest.TestTechnology,
            bogus: -1
-         }}
+         }},
+        {"invalid_config", :this, :should, :be, :ignored, :with, :a, :warning}
       ])
 
       VintageNet.Persistence.call(:save, [


### PR DESCRIPTION
When a user provides an invalid configuration in the application config
file, we now will filter those out and provide a warning message.
