### PR TITLE
Fix regression with udhcpd lease notifications

### DIFF
--- a/lib/vintage_net/os_event_dispatcher.ex
+++ b/lib/vintage_net/os_event_dispatcher.ex
@@ -14,11 +14,6 @@ defmodule VintageNet.OSEventDispatcher do
   OS environment.
   """
   @spec dispatch([String.t()], %{String.t() => String.t()}) :: :ok
-  def dispatch(["udhcpd." <> ifname_leases = lease_file], _env) do
-    [ifname, "leases"] = String.split(ifname_leases, ".", parts: 2)
-    handler = Application.get_env(:vintage_net, :udhcpd_handler)
-    apply(handler, :lease_update, [ifname, lease_file])
-  end
 
   def dispatch([op], %{"interface" => ifname} = info)
       when op in ["deconfig", "leasefail", "nak", "renew", "bound"] do
@@ -29,8 +24,29 @@ defmodule VintageNet.OSEventDispatcher do
     apply(handler, String.to_atom(op), [ifname, new_info])
   end
 
+  def dispatch([lease_file], _env) do
+    case extract_lease_file_ifname(lease_file) do
+      {:ok, ifname} ->
+        handler = Application.get_env(:vintage_net, :udhcpd_handler)
+        apply(handler, :lease_update, [ifname, lease_file])
+
+      :error ->
+        Logger.warn("VintageNet: dropping unexpected notification: [#{inspect(lease_file)}]")
+    end
+  end
+
   def dispatch(args, _env) do
     Logger.warn("VintageNet: dropping unexpected notification: #{inspect(args)}")
+  end
+
+  defp extract_lease_file_ifname(path) do
+    # "/tmp/vintage_net/udhcpd.wlan0.leases"
+    base = Path.basename(path)
+
+    case String.split(base, ".", parts: 3) do
+      ["udhcpd", ifname, "leases"] -> {:ok, ifname}
+      _ -> :error
+    end
   end
 
   # This preserves the behavior of an earlier version of this code.


### PR DESCRIPTION
At some point the udhcpd lease notification changed from using a
relative path to an absolute path. This broke a pattern match that was
identifying the message and extracting the ifname. This change fixes the
issue.

Fixes #288.
