### PR TITLE
Harden app env checks; silently add default_config

### DIFF
--- a/lib/vintage_net.ex
+++ b/lib/vintage_net.ex
@@ -165,7 +165,7 @@ defmodule VintageNet do
   end
 
   defp default_config(ifname) do
-    Application.get_env(:vintage_net, :config)
+    VintageNet.Application.get_config_env()
     |> List.keyfind(ifname, 0)
     |> case do
       {^ifname, config} -> config

--- a/test/vintage_net/application_test.exs
+++ b/test/vintage_net/application_test.exs
@@ -1,0 +1,88 @@
+defmodule VintageNet.ApplicationTest do
+  use ExUnit.Case
+  doctest VintageNet.Application
+
+  import ExUnit.CaptureLog
+
+  @test_config [{"bogus1", %{type: VintageNetTest.TestTechnology, bogus: 1}}]
+  @test_config2 [{"bogus2", %{type: VintageNetTest.TestTechnology, bogus: 2}}]
+
+  setup do
+    # Clean up after each test
+    on_exit(fn ->
+      Application.put_env(:vintage_net, :config, [])
+      Application.put_env(:vintage_net, :default_config, nil)
+    end)
+
+    :ok
+  end
+
+  test "configs are read from the config key" do
+    Application.put_env(:vintage_net, :config, @test_config)
+    assert VintageNet.Application.get_config_env() == @test_config
+  end
+
+  test "configs are read from the default_config key" do
+    Application.put_env(:vintage_net, :default_config, @test_config)
+    assert VintageNet.Application.get_config_env() == @test_config
+  end
+
+  test "the default_config key is preferred" do
+    Application.put_env(:vintage_net, :config, @test_config)
+    Application.put_env(:vintage_net, :default_config, @test_config2)
+    assert VintageNet.Application.get_config_env() == @test_config2
+  end
+
+  # test common config mistakes
+  test "drops configs with atom ifnames" do
+    Application.put_env(
+      :vintage_net,
+      :default_config,
+      @test_config2 ++ [{:wlan0, %{type: :atom_bad}}]
+    )
+
+    log =
+      capture_log(fn ->
+        assert VintageNet.Application.get_config_env() == @test_config2
+      end)
+
+    assert log =~ "Dropping invalid configuration"
+  end
+
+  test "drops configs with no type" do
+    Application.put_env(
+      :vintage_net,
+      :default_config,
+      @test_config2 ++ [{"wlan0", %{}}]
+    )
+
+    log =
+      capture_log(fn ->
+        assert VintageNet.Application.get_config_env() == @test_config2
+      end)
+
+    assert log =~ "Dropping invalid configuration"
+  end
+
+  test "drops configs missing tuple" do
+    Application.put_env(
+      :vintage_net,
+      :default_config,
+      @test_config2 ++ ["wlan0"]
+    )
+
+    log =
+      capture_log(fn ->
+        assert VintageNet.Application.get_config_env() == @test_config2
+      end)
+
+    assert log =~ "Dropping invalid configuration"
+  end
+
+  test "handles forgotten configs" do
+    Application.put_env(:vintage_net, :default_config, nil)
+    Application.put_env(:vintage_net, :config, nil)
+
+    assert VintageNet.Application.get_config_env() == []
+  end
+end


### PR DESCRIPTION
This funnels the call to get configs through one place. There was a
missed call in `vintage_net.ex` that would have crashed if the
environment was bad. This also adds a few unit tests to make sure that
the invalid config filter works and logs a warning.

Finally, this silently adds the `:default_config` key so that we can
switch the configuration key to it in a future major release without
breaking people who back off to old `:vintage_net` releases for testing
(probably just me). The intention of `:default_config` is to reduce the
confusion of why the network configuration doesn't change when you
change the application config. I.e., it's not a configuration, it's a
"default" configuration that's only used if the interface is available
and nothing has been configured on top of it.
