### PR TITLE
Add WiFi + static IP example in the cookbook

### DIFF
--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -124,6 +124,30 @@ keys.
 }
 ```
 
+Here are example parameters for an static IP address.
+
+```elixir
+%{
+  type: VintageNetWiFi,
+  vintage_net_wifi: %{
+    networks: [
+      %{
+        key_mgmt: :wpa_psk,
+        ssid: "my_network_ssid",
+        psk: "a_passphrase_or_psk"
+      }
+    ]
+  },
+  ipv4: %{
+    method: :static,
+    address: "192.168.9.232",
+    prefix_length: 24,
+    gateway: "192.168.9.1",
+    name_servers: ["1.1.1.1"]
+  }
+}
+```
+
 If you're regularly switching between multiple networks, you can list them all
 under the `:networks` key. Note that it's currently not possible to mix networks
 that require static IP addresses with those that use DHCP.


### PR DESCRIPTION
I don't know if this is useful but I just thought it would be nice to have a WiFi(WPA2 PSK) + Static IP example for completeness. 

I am unfamiliar with networking things so I just place minimal text. If somebody comes up with better description, I'd be happy to update it.