### PR TITLE
Do not bounce route on trivial DHCP renewal

### DIFF
--- a/lib/vintage_net/interface/udhcpc.ex
+++ b/lib/vintage_net/interface/udhcpc.ex
@@ -104,7 +104,7 @@ defmodule VintageNet.Interface.Udhcpc do
 
         {:ok, default_gateway} = IP.ip_to_tuple(first_router)
 
-        RouteManager.set_route(ifname, [ip_subnet], default_gateway, :lan)
+        RouteManager.set_route(ifname, [ip_subnet], default_gateway)
 
       _ ->
         :ok

--- a/lib/vintage_net/ip/ipv4_config.ex
+++ b/lib/vintage_net/ip/ipv4_config.ex
@@ -209,7 +209,7 @@ defmodule VintageNet.IP.IPv4Config do
 
         gateway ->
           {:fun, VintageNet.RouteManager, :set_route,
-           [ifname, [{ipv4.address, ipv4.prefix_length}], gateway, :lan]}
+           [ifname, [{ipv4.address, ipv4.prefix_length}], gateway]}
       end
 
     resolver_up =

--- a/test/vintage_net/ip/ipv4_config_test.exs
+++ b/test/vintage_net/ip/ipv4_config_test.exs
@@ -138,7 +138,7 @@ defmodule VintageNet.IP.IPv4ConfigTest do
         {:run, "ip", ["addr", "add", "192.168.1.2/24", "dev", "eth0", "label", "eth0"]},
         {:run, "ip", ["link", "set", "eth0", "up"]},
         {:fun, VintageNet.RouteManager, :set_route,
-         ["eth0", [{{192, 168, 1, 2}, 24}], {192, 168, 1, 1}, :lan]},
+         ["eth0", [{{192, 168, 1, 2}, 24}], {192, 168, 1, 1}]},
         {:fun, VintageNet.NameResolver, :setup,
          ["eth0", "example.com", [{1, 1, 1, 1}, {8, 8, 8, 8}]]}
       ]


### PR DESCRIPTION
The original assumption was that since DHCP renewals could change IP
addresses that the connection status should be bounced to `:lan` and
then updated to `:internet` after checking connectivity. Nearly all DHCP
renewals don't change IP parameters, they just renew the IP lease for
another 24 hours (or whatever). This change ignores renewals that don't
change IP parameters.

Since switching routes from `:lan` to `:internet` can change routes to
when a device has more than one interface, this bouncing to
`:lan` and back caused connections to be dropped and reestablished. This
got noticed. The reconnects tend to happen daily at the same time since
many DHCP leases are for 24 hours.

Due to the way the RouteManager was written, then change is a little
hard to test. To try it out, watch the log and run:

```elixir
iex> cmd("killall -s USR1 udhcpc")
```

This will cause `udhcpc` to renew the lease. You should see log messages
like this:

```
19:23:46.482 [debug] udhcpc(wlan0): udhcpc: lease of 192.168.1.101 obtained, lease time 86400

19:23:46.501 [info]  RouteManager: set_route wlan0 ignored since no change.
```
