### PR TITLE
Makefile improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,9 +77,11 @@ $(PREFIX)/if_monitor: $(BUILD)/if_monitor.o
 $(PREFIX) $(BUILD):
 	mkdir -p $@
 
-clean:
+mix_clean:
 	$(RM) $(PREFIX)/if_monitor \
 	    $(BUILD)/*.o
+clean:
+	mix clean
 
 format:
 	astyle \
@@ -95,7 +97,7 @@ format:
 	    --pad-oper \
 	    src/*.c
 
-.PHONY: all clean calling_from_make install format
+.PHONY: all clean mix_clean calling_from_make install format
 
 # Don't echo commands unless the caller exports "V=1"
 ${V}.SILENT:

--- a/Makefile
+++ b/Makefile
@@ -67,9 +67,11 @@ all: install
 install: $(BUILD) $(PREFIX) $(DEFAULT_TARGETS)
 
 $(BUILD)/%.o: src/%.c
+	@echo " CC $(notdir $@)"
 	$(CC) -c $(ERL_CFLAGS) $(CFLAGS) -o $@ $<
 
 $(PREFIX)/if_monitor: $(BUILD)/if_monitor.o
+	@echo " LD $(notdir $@)"
 	$(CC) $^ $(ERL_LDFLAGS) $(LDFLAGS) -lmnl -o $@
 
 $(PREFIX) $(BUILD):
@@ -94,3 +96,6 @@ format:
 	    src/*.c
 
 .PHONY: all clean calling_from_make install format
+
+# Don't echo commands unless the caller exports "V=1"
+${V}.SILENT:

--- a/mix.exs
+++ b/mix.exs
@@ -15,7 +15,7 @@ defmodule VintageNet.MixProject do
       build_embedded: true,
       compilers: [:elixir_make | Mix.compilers()],
       make_targets: ["all"],
-      make_clean: ["clean"],
+      make_clean: ["mix_clean"],
       make_error_message: "",
       deps: deps(),
       dialyzer: dialyzer(),


### PR DESCRIPTION
This has two improvements. The first removes the long gcc invocations. Here's the before:

```
$ mix compile
mkdir -p /home/fhunleth/git/nerves-networking/vintage_net/_build/dev/lib/vintage_net/obj
mkdir -p /home/fhunleth/git/nerves-networking/vintage_net/_build/dev/lib/vintage_net/priv
cc -c -I/home/fhunleth/.asdf/installs/erlang/24.0.2/usr/include -O2 -Wall -Wextra -Wno-unused-parameter -pedantic -std=c99 -D_XOPEN_SOURCE=600 -o /home/fhunleth/git/nerves-networking/vintage_net/_build/dev/lib/vintage_net/obj/if_monitor.o src/if_monitor.c
cc /home/fhunleth/git/nerves-networking/vintage_net/_build/dev/lib/vintage_net/obj/if_monitor.o -L/home/fhunleth/.asdf/installs/erlang/24.0.2/usr/lib -lei_st  -lmnl -o /home/fhunleth/git/nerves-networking/vintage_net/_build/dev/lib/vintage_net/priv/if_monitor
Compiling 50 files (.ex)
Generated vintage_net app
```

And here's afterwards:

```
$ mix compile
 CC if_monitor.o
 LD if_monitor
Compiling 50 files (.ex)
Generated vintage_net app
```

And here's how to get the prints back:

```
$ V=1 mix compile
mkdir -p /home/fhunleth/git/nerves-networking/vintage_net/_build/dev/lib/vintage_net/obj
mkdir -p /home/fhunleth/git/nerves-networking/vintage_net/_build/dev/lib/vintage_net/priv
 CC if_monitor.o
cc -c -I/home/fhunleth/.asdf/installs/erlang/24.0.2/usr/include -O2 -Wall -Wextra -Wno-unused-parameter -pedantic -std=c99 -D_XOPEN_SOURCE=600 -o /home/fhunleth/git/nerves-networking/vintage_net/_build/dev/lib/vintage_net/obj/if_monitor.o src/if_monitor.c
 LD if_monitor
cc /home/fhunleth/git/nerves-networking/vintage_net/_build/dev/lib/vintage_net/obj/if_monitor.o -L/home/fhunleth/.asdf/installs/erlang/24.0.2/usr/lib -lei_st  -lmnl -o /home/fhunleth/git/nerves-networking/vintage_net/_build/dev/lib/vintage_net/priv/if_monitor
Compiling 50 files (.ex)
Generated vintage_net app
```

The second makes `make clean` always work.