### PR TITLE
Internet connectivity checker: remove unfixable transition

### DIFF
--- a/lib/vintage_net/interface/internet_connectivity_checker.ex
+++ b/lib/vintage_net/interface/internet_connectivity_checker.ex
@@ -131,7 +131,10 @@ defmodule VintageNet.Interface.InternetConnectivityChecker do
   end
 
   def update_state_from_ping(state, {:error, :if_not_found}) do
-    %{state | connectivity: :disconnected, strikes: @max_fails_in_a_row}
+    # The connectivity is likely going to be disconnected, but don't
+    # only let `lower_up` being false set disconnected, since there's
+    # no way to get out of disconnected without a `lower_up` transition.
+    %{state | connectivity: :lan, strikes: @max_fails_in_a_row}
   end
 
   def update_state_from_ping(state, {:error, :no_ipv4_address}) do

--- a/test/vintage_net/interface/internet_connectivity_checker_test.exs
+++ b/test/vintage_net/interface/internet_connectivity_checker_test.exs
@@ -18,19 +18,19 @@ defmodule VintageNet.Interface.InternetConnectivityCheckerTest do
              ) ==
                %{ifname: "bogus0", connectivity: :internet, hosts: [2, 1], strikes: 1}
 
-      # No IP address reverts to LAN
+      # No IP address reverts to :lan
       assert InternetConnectivityChecker.update_state_from_ping(
                base_state,
                {:error, :no_ipv4_address}
              ) ==
                %{ifname: "bogus0", connectivity: :lan, hosts: [1, 2], strikes: 3}
 
-      # No interfaces goes to disconnected
+      # No interfaces goes to :lan
       assert InternetConnectivityChecker.update_state_from_ping(
                base_state,
                {:error, :if_not_found}
              ) ==
-               %{ifname: "bogus0", connectivity: :disconnected, hosts: [1, 2], strikes: 3}
+               %{ifname: "bogus0", connectivity: :lan, hosts: [1, 2], strikes: 3}
 
       # Check 3 strikes reverts to :lan
       base_state = %{ifname: "bogus0", connectivity: :internet, strikes: 2, hosts: [1, 2]}
@@ -56,12 +56,12 @@ defmodule VintageNet.Interface.InternetConnectivityCheckerTest do
       assert InternetConnectivityChecker.update_state_from_ping(base_state, :ok) ==
                %{ifname: "bogus0", connectivity: :internet, hosts: [1, 2], strikes: 0}
 
-      # No interfaces goes to disconnected
+      # No interfaces goes to :lan
       assert InternetConnectivityChecker.update_state_from_ping(
                base_state,
                {:error, :if_not_found}
              ) ==
-               %{ifname: "bogus0", connectivity: :disconnected, hosts: [1, 2], strikes: 3}
+               %{ifname: "bogus0", connectivity: :lan, hosts: [1, 2], strikes: 3}
     end
 
     test "disconnected scenarios" do


### PR DESCRIPTION
If a "ping" returned that there wasn't a network interface to ping, this
would lead to the interface being marked disconnected with no way of
escaping if it was a transient error.

The original assumption was that if ping return this that it was just a
matter of time before the interface went down. However, if there's a
transient or unfortunate ordering of events and this happened, then the
checker would stop polling and the interface could never be marked as
internet-connected.
