### PR TITLE
Rotate IP checklist for internet connectivity checker on failure

### DIFF
--- a/lib/vintage_net/interface/internet_connectivity_checker.ex
+++ b/lib/vintage_net/interface/internet_connectivity_checker.ex
@@ -146,10 +146,10 @@ defmodule VintageNet.Interface.InternetConnectivityChecker do
         "#{state.ifname}: Internet check failed to #{inspect(hd(state.hosts))} (#{inspect(reason)}): #{strikes}/#{@max_fails_in_a_row} strikes"
       )
 
-      %{state | connectivity: :internet, strikes: strikes, hosts: rotate_list(state.hosts)}
+      %{state | strikes: strikes, hosts: rotate_list(state.hosts)}
     else
       Logger.debug("#{state.ifname}: Internet unreachable: (#{inspect(reason)})")
-      %{state | connectivity: :lan, strikes: @max_fails_in_a_row}
+      %{state | connectivity: :lan, strikes: @max_fails_in_a_row, hosts: rotate_list(state.hosts)}
     end
   end
 

--- a/test/vintage_net/interface/internet_connectivity_checker_test.exs
+++ b/test/vintage_net/interface/internet_connectivity_checker_test.exs
@@ -39,7 +39,7 @@ defmodule VintageNet.Interface.InternetConnectivityCheckerTest do
                base_state,
                {:error, :ehostdown}
              ) ==
-               %{ifname: "bogus0", connectivity: :lan, hosts: [1, 2], strikes: 3}
+               %{ifname: "bogus0", connectivity: :lan, hosts: [2, 1], strikes: 3}
     end
 
     test "lan scenarios" do


### PR DESCRIPTION
There was a rotation missing here. This also removes a redundant setting
of internet connectivity.
