### PR TITLE
Update VintageNet.Interface.*ConnectivityChecker refs

### DIFF
--- a/lib/vintage_net/ip/ipv4_config.ex
+++ b/lib/vintage_net/ip/ipv4_config.ex
@@ -179,7 +179,7 @@ defmodule VintageNet.IP.IPv4Config do
              ]},
             id: :udhcpc
           ),
-          {VintageNet.Interface.InternetConnectivityChecker, ifname}
+          {VintageNet.Connectivity.InternetChecker, ifname}
         ]
 
     %RawConfig{
@@ -241,8 +241,8 @@ defmodule VintageNet.IP.IPv4Config do
     # If there's a default gateway, then check for internet connectivity.
     checker =
       case ipv4[:gateway] do
-        nil -> {VintageNet.Interface.LANConnectivityChecker, ifname}
-        _exists -> {VintageNet.Interface.InternetConnectivityChecker, ifname}
+        nil -> {VintageNet.Connectivity.LANChecker, ifname}
+        _exists -> {VintageNet.Connectivity.InternetChecker, ifname}
       end
 
     new_child_specs = child_specs ++ [checker]

--- a/test/vintage_net/ip/ipv4_config_test.exs
+++ b/test/vintage_net/ip/ipv4_config_test.exs
@@ -85,7 +85,7 @@ defmodule VintageNet.IP.IPv4ConfigTest do
       required_ifnames: ["eth0"],
       child_specs: [
         udhcpc_child_spec("eth0", "unit_test"),
-        {VintageNet.Interface.InternetConnectivityChecker, "eth0"}
+        {VintageNet.Connectivity.InternetChecker, "eth0"}
       ],
       down_cmds: [
         {:run_ignore_errors, "ip", ["addr", "flush", "dev", "eth0", "label", "eth0"]},
@@ -125,7 +125,7 @@ defmodule VintageNet.IP.IPv4ConfigTest do
       source_config: input,
       required_ifnames: ["eth0"],
       child_specs: [
-        {VintageNet.Interface.InternetConnectivityChecker, "eth0"}
+        {VintageNet.Connectivity.InternetChecker, "eth0"}
       ],
       down_cmds: [
         {:fun, VintageNet.RouteManager, :clear_route, ["eth0"]},
@@ -172,7 +172,7 @@ defmodule VintageNet.IP.IPv4ConfigTest do
       source_config: input,
       required_ifnames: ["eth0"],
       child_specs: [
-        {VintageNet.Interface.LANConnectivityChecker, "eth0"}
+        {VintageNet.Connectivity.LANChecker, "eth0"}
       ],
       down_cmds: [
         {:fun, VintageNet.RouteManager, :clear_route, ["eth0"]},
@@ -218,7 +218,7 @@ defmodule VintageNet.IP.IPv4ConfigTest do
       source_config: input,
       required_ifnames: ["eth0"],
       child_specs: [
-        {VintageNet.Interface.LANConnectivityChecker, "eth0"}
+        {VintageNet.Connectivity.LANChecker, "eth0"}
       ],
       down_cmds: [
         {:fun, VintageNet.RouteManager, :clear_route, ["eth0"]},


### PR DESCRIPTION
This change will fail unit tests on projects that depend on this one and
force the `VintageNet.Interface.*ConnectivityChecker` to
`VintageNet.Connectivity.*Checker` update.
