### PR TITLE
Make resolv.conf generation more deterministic

### DIFF
--- a/lib/vintage_net/name_resolver.ex
+++ b/lib/vintage_net/name_resolver.ex
@@ -85,6 +85,7 @@ defmodule VintageNet.NameResolver do
     additional_name_servers =
       Keyword.get(args, :additional_name_servers, [])
       |> Enum.reduce([], &ip_to_tuple_safe/2)
+      |> Enum.reverse()
 
     state = %State{
       path: resolvconf_path,

--- a/lib/vintage_net/resolver/resolv_conf.ex
+++ b/lib/vintage_net/resolver/resolv_conf.ex
@@ -19,10 +19,7 @@ defmodule VintageNet.Resolver.ResolvConf do
   @spec to_config(entry_map(), additional_name_servers) :: iolist()
   def to_config(entries, additional_name_servers) do
     domains = Enum.reduce(entries, %{}, &add_domain/2)
-    name_servers = Enum.reduce(entries, %{}, &add_name_servers/2)
-
-    name_servers =
-      Enum.reduce(additional_name_servers, name_servers, &add_name_server("global", &1, &2))
+    name_servers = entries_to_name_servers(entries, additional_name_servers)
 
     [
       "# This file is managed by VintageNet. Do not edit.\n\n",
@@ -31,11 +28,20 @@ defmodule VintageNet.Resolver.ResolvConf do
     ]
   end
 
-  defp domain_text({domain, ifnames}),
-    do: ["search ", domain, " # From ", Enum.join(ifnames, ","), "\n"]
+  defp entries_to_name_servers(entries, additional_name_servers) do
+    # This is trickier than it looks since we want the ordering of name
+    # servers to be deterministic. Here are the rules:
+    #
+    # 1. No duplicates entries (interfaces can supply similar entries to this is a common case)
+    # 2. Entries listed in the order supplied if possible. It's possible that
+    #    that two interfaces specify the same entries in a different order, so don't try to fix that.
+    # 3. Global entries are always first
 
-  defp name_server_text({server, ifnames}),
-    do: ["nameserver ", IP.ip_to_string(server), " # From ", Enum.join(ifnames, ","), "\n"]
+    Enum.reduce(entries, %{}, &add_name_servers(&2, &1))
+    |> add_name_servers({"global", %{name_servers: additional_name_servers}})
+    |> Enum.map(&sort_ifname_lists/1)
+    |> Enum.sort(&name_server_lte/2)
+  end
 
   defp add_domain({ifname, %{domain: domain}}, acc) when is_binary(domain) and domain != "" do
     Map.update(acc, domain, [ifname], fn ifnames -> [ifname | ifnames] end)
@@ -43,11 +49,63 @@ defmodule VintageNet.Resolver.ResolvConf do
 
   defp add_domain(_other, acc), do: acc
 
-  defp add_name_servers({ifname, %{name_servers: servers}}, acc) do
-    Enum.reduce(servers, acc, &add_name_server(ifname, &1, &2))
+  defp add_name_servers(name_servers, {ifname, %{name_servers: servers}}) do
+    indexed_servers = Enum.with_index(servers)
+    Enum.reduce(indexed_servers, name_servers, &add_name_server(ifname, &1, &2))
   end
 
-  defp add_name_server(ifname, server, acc) do
-    Map.update(acc, server, [ifname], fn ifnames -> [ifname | ifnames] end)
+  defp add_name_server(ifname, {server, index}, acc) do
+    ifname_index = {ifname, index}
+    Map.update(acc, server, [ifname_index], fn ifnames -> [ifname_index | ifnames] end)
+  end
+
+  defp sort_ifname_lists({ns, ifname_index_list}) do
+    sorted_list = Enum.sort(ifname_index_list, &ifname_ix_compare/2)
+    {ns, sorted_list}
+  end
+
+  defp ifname_ix_compare({ifname, ix1}, {ifname, ix2}), do: ix1 <= ix2
+  defp ifname_ix_compare({"global", _ix1}, _not_global), do: true
+  defp ifname_ix_compare(_not_global, {"global", _ix2}), do: false
+  defp ifname_ix_compare({ifname1, _ix1}, {ifname2, _ix2}), do: ifname1 <= ifname2
+
+  defp name_server_lte(
+         {_ns1, ifname_index_list1} = a,
+         {_ns2, ifname_index_list2} = b,
+         ifname \\ "global"
+       ) do
+    index1 = find_ifname_index(ifname_index_list1, ifname)
+    index2 = find_ifname_index(ifname_index_list2, ifname)
+
+    case {index1, index2} do
+      {nil, nil} ->
+        # The lists are sorted by this point so arbitrarily pick
+        # the first one's list to choose the ifname to compare.
+        # Note that the recursive call is guaranteed not to hit
+        # this case again since index1 will be found.
+        [{first_ifname, _index} | _] = ifname_index_list1
+        name_server_lte(a, b, first_ifname)
+
+      {nil, _not_nil} ->
+        false
+
+      {_not_nil, nil} ->
+        true
+
+      {_not_nil, _not_nil2} ->
+        index1 <= index2
+    end
+  end
+
+  defp find_ifname_index([], _ifname), do: nil
+  defp find_ifname_index([{ifname, index} | _rest], ifname), do: index
+  defp find_ifname_index([_no | rest], ifname), do: find_ifname_index(rest, ifname)
+
+  defp domain_text({domain, ifnames}),
+    do: ["search ", domain, " # From ", Enum.intersperse(ifnames, ","), "\n"]
+
+  defp name_server_text({server, ifname_orders}) do
+    ifnames = Enum.map(ifname_orders, fn {ifname, _} -> ifname end)
+    ["nameserver ", IP.ip_to_string(server), " # From ", Enum.intersperse(ifnames, ","), "\n"]
   end
 end


### PR DESCRIPTION
This sorts the resolv.conf entries such that global name servers always
come first and in the order that they're specified. After the global
name servers, try to follow the order that DHCP servers or static
configurations specify.  There isn't an attempt to be perfect here since
you could come of with interfaces specifying opposing orders and it
probably wouldn't matter or be that common.

The importance of being more deterministic is that DNS queries go to the
servers in the order listed. If you specify a set of DNS servers to be
used globally, you probably expect them to be queried before anything
supplied by DHCP. Previously the server IP address had an effect on the
order due to the use of maps to collect servers. This led to a confusing
bug different behavior was observed in two different places that was
traced down to on subnet being a 10.x.x.x and the other being a
192.168.x.x and this changing the resolver order.
