### PR TITLE
Document that VintageNet persists by default

### DIFF
--- a/lib/vintage_net.ex
+++ b/lib/vintage_net.ex
@@ -159,7 +159,7 @@ defmodule VintageNet do
   Options:
 
   * `:persist` - set to `false` to avoid persisting this configuration. System
-    restarts will revert to the previous configuration.
+    restarts will revert to the previous configuration. Defaults to true.
   """
   @spec configure(ifname(), map(), configure_options()) :: :ok | {:error, any()}
   def configure(ifname, config, options \\ []) do
@@ -167,7 +167,7 @@ defmodule VintageNet do
   end
 
   @doc """
-  Deconfigure settings for a specified interface.
+  Deconfigure and persists (by default) settings for a specified interface.
 
   Supports same options as `configure/3`
   """


### PR DESCRIPTION
It was not clear from the docs and I had to read the code to be sure.

As a side note I was really expecting the configuration to not persist by default, and I'd support changing the default to false (of course the wifi wizard would keep it's same behavior which I assume is persisting by default). This caused me to have to rewrite https://github.com/nerves-networking/vintage_net_wifi/issues/92 twice.