### PR TITLE
Fix default internet checking hosts data structure

### DIFF
--- a/lib/vintage_net/connectivity/internet_checker.ex
+++ b/lib/vintage_net/connectivity/internet_checker.ex
@@ -142,7 +142,7 @@ defmodule VintageNet.Connectivity.InternetChecker do
 
     if good_hosts == [] do
       Logger.warn("VintageNet: `:internet_host_list` is invalid. Using defaults")
-      [{1, 1, 1, 1}, 80]
+      [{{1, 1, 1, 1}, 80}]
     else
       good_hosts
     end


### PR DESCRIPTION
When the `:internet_host_list` configuration item is miss configured, meaning there are [no good hosts](https://github.com/nerves-networking/vintage_net/blob/1ecb4f512c2ce90b324be7a5711d6772b812ae8f/lib/vintage_net/connectivity/internet_checker.ex#L143) and VintageNet tries to fall back to the defaults this error occurs:

```elixir
17:12:21.110 [warn]  VintageNet: `:internet_host_list` is invalid. Using defaults

17:12:21.614 [error] GenServer #PID<0.1973.0> terminating
** (FunctionClauseError) no function clause matching in VintageNet.Connectivity.TCPPing.ping/2
    (vintage_net 0.11.3) lib/vintage_net/connectivity/tcp_ping.ex:31: VintageNet.Connectivity.TCPPing.ping("wlan0", {1, 1, 1, 1})
    (vintage_net 0.11.3) lib/vintage_net/connectivity/internet_checker.ex:108: VintageNet.Connectivity.InternetChecker.check_connectivity/1
    (vintage_net 0.11.3) lib/vintage_net/connectivity/internet_checker.ex:65: VintageNet.Connectivity.InternetChecker.handle_info/2
    (stdlib 3.16.1) gen_server.erl:695: :gen_server.try_dispatch/4
    (stdlib 3.16.1) gen_server.erl:771: :gen_server.handle_msg/6
    (stdlib 3.16.1) proc_lib.erl:226: :proc_lib.init_p_do_apply/3
Last message: :timeout
State: %{hosts: [{1, 1, 1, 1}, 80], ifname: "wlan0", inspector: %{}, status: %{connectivity: :lan, interval: 500, strikes: 3}}
```

This is because the state of the internet connectivity checker server `:hosts` field becomes  the type `[VintageNet.any_ip_address() | integer()]` rather than the [expected](https://github.com/nerves-networking/vintage_net/blob/1ecb4f512c2ce90b324be7a5711d6772b812ae8f/lib/vintage_net/connectivity/internet_checker.ex#L19): `[{VintageNet.any_ip_address(), integer()}]` . 

When the checker calls `TCPPing.ping/2` it [calls](https://github.com/nerves-networking/vintage_net/blob/1ecb4f512c2ce90b324be7a5711d6772b812ae8f/lib/vintage_net/connectivity/internet_checker.ex#L108) `hd/1` on the `:hosts` list field. Since our type is now a list of tuples or integers, rather than a list of tuples like expected, the result from `hd/1` is `{1, 1, 1, 1}`. 

Passing `{1, 1, 1, 1}` to `TCPPing.ping/2` as the second argument [will not match](https://github.com/nerves-networking/vintage_net/blob/1ecb4f512c2ce90b324be7a5711d6772b812ae8f/lib/vintage_net/connectivity/tcp_ping.ex#L31) as `TCPPing.ping/2` matches the type `{VintageNet.any_ip_address, non_neg_integer()}` causes the `FunctionClauseError`. 

Moreover, this appears to break the ability to use ssh, so doing firmware updates over the air stop working and I am forced to `mix burn` to fix.

To reproduce issue set the `:vintage_net` configuration field `:internet_host_list` to `[]`. However, be sure to have a way to update new firmware outside of ssh.