### PR TITLE
Improve ifname choice when testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
       - <<: *install_system_deps
       - restore_cache:
           keys:
-            - v1-mix-cache-{{ checksum "mix.lock" }}
+            - v2-mix-cache-{{ checksum "mix.lock" }}
       - run: mix deps.get
       - run: mix test --exclude requires_ipv6
       - run: mix format --check-formatted
@@ -40,10 +40,9 @@ jobs:
       - run: mix dialyzer
       - run: mix coveralls.circle || true
       - save_cache:
-          key: v1-mix-cache-{{ checksum "mix.lock" }}
+          key: v2-mix-cache-{{ checksum "mix.lock" }}
           paths:
-            - _build
-            - deps
+            - _build/plts
 
   build_elixir_1_12_otp_24:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,9 +19,9 @@ install_system_deps: &install_system_deps
         apk add build-base linux-headers libmnl-dev libnl3-dev git
 
 jobs:
-  build_elixir_1_12_otp_24:
+  build_elixir_1_13_otp_24:
     docker:
-      - image: hexpm/elixir:1.12.3-erlang-24.1.1-alpine-3.14.0
+      - image: hexpm/elixir:1.13.1-erlang-24.2-alpine-3.14.2
     <<: *defaults
     steps:
       - checkout
@@ -44,6 +44,17 @@ jobs:
           paths:
             - _build
             - deps
+
+  build_elixir_1_12_otp_24:
+    docker:
+      - image: hexpm/elixir:1.12.3-erlang-24.1.1-alpine-3.14.0
+    <<: *defaults
+    steps:
+      - checkout
+      - <<: *install_hex_rebar
+      - <<: *install_system_deps
+      - run: mix deps.get
+      - run: mix test --exclude requires_ipv6
 
   build_elixir_1_11_otp_23:
     docker:
@@ -82,6 +93,7 @@ workflows:
   version: 2
   build_test:
     jobs:
+      - build_elixir_1_13_otp_24
       - build_elixir_1_12_otp_24
       - build_elixir_1_11_otp_23
       - build_elixir_1_10_otp_23

--- a/mix.exs
+++ b/mix.exs
@@ -115,7 +115,8 @@ defmodule VintageNet.MixProject do
   defp dialyzer() do
     [
       flags: [:race_conditions, :unmatched_returns, :error_handling, :underspecs],
-      list_unused_filters: true
+      list_unused_filters: true,
+      plt_file: {:no_warn, "_build/plts/dialyzer.plt"}
     ]
   end
 


### PR DESCRIPTION
This further requires the network interface chosen for the unit tests to
have an IPv4 address. Interfaces with only IPv6 addresses probably don't
go to the internet.
