### PR TITLE
Print the mac address of the interface

### DIFF
--- a/lib/vintage_net/info.ex
+++ b/lib/vintage_net/info.ex
@@ -56,6 +56,7 @@ defmodule VintageNet.Info do
         format_if_attribute(ifname, "state", "State", true),
         format_if_attribute(ifname, "connection", "Connection", true),
         format_addresses(ifname),
+        format_if_attribute(ifname, "mac_address", "MAC Address"),
         "  Configuration:\n",
         format_config(ifname, "    ", opts),
         "\n"


### PR DESCRIPTION
As discussed on Slack
Tested on my RPI 3B+

I didn't see anywhere relevant to update a test so I didn't update any tests.

Output looks like this on my device:
```
Interface wlan0
  Type: VintageNetWiFi
  Present: true
  State: :configured (0:01:25)
  Connection: :internet (0:01:18)
  Addresses: fe80::ba27:ebff:fe76:2abc/64, 192.168.1.2/24
  MAC Address: "b8:27:eb:76:6e:aa"
  Configuration:
    %{
      ipv4: %{method: :dhcp},
      type: VintageNetWiFi,
      vintage_net_wifi: %{
        networks: [
          %{
            key_mgmt: :wpa_psk,
            mode: :infrastructure,
            psk: "....",
            ssid: "some-wifi-network"
          }
        ]
      }
    }
```