### PR TITLE
Fix old use of :unavailable

### DIFF
--- a/lib/vintage_net/connectivity/inspector.ex
+++ b/lib/vintage_net/connectivity/inspector.ex
@@ -64,7 +64,7 @@ defmodule VintageNet.Connectivity.Inspector do
   network interface has send AND received data since the previous call, then
   `:internet` is returned. If not, then usually `:unknown` is returned to
   signify that internet may be available, but we just don't know. If the
-  interface doesn't have an IP address, then `:unavailable` is returned, since
+  interface doesn't have an IP address, then `:no_internet` is returned, since
   that's a prerequisite to communicating with anyone on the internet.
   """
   @spec check_internet(VintageNet.ifname(), cache()) :: result()
@@ -72,7 +72,7 @@ defmodule VintageNet.Connectivity.Inspector do
     case get_addresses(ifname) do
       [] ->
         # If we don't even have an IP address, then there's no Internet for sure.
-        {:unavailable, %{}}
+        {:no_internet, %{}}
 
       our_addresses ->
         {:unknown, %{}}

--- a/test/vintage_net/connectivity/inspector_test.exs
+++ b/test/vintage_net/connectivity/inspector_test.exs
@@ -104,6 +104,6 @@ defmodule VintageNet.Connectivity.InspectorTest do
   end
 
   test "checking the internet of a bogus network interface fails nicely" do
-    assert Inspector.check_internet("bogus0", %{}) == {:unavailable, %{}}
+    assert Inspector.check_internet("bogus0", %{}) == {:no_internet, %{}}
   end
 end


### PR DESCRIPTION
This fixes the following crash:

```
23:42:28.197 [error] GenServer #PID<0.3941.0> terminating
** (FunctionClauseError) no function clause matching in VintageNet.Connectivity.InternetChecker.update_check_logic/1
    (vintage_net 0.11.4) lib/vintage_net/connectivity/internet_checker.ex:155: VintageNet.Connectivity.InternetChecker.update_check_logic(%{check_logic: %{connectivity: :lan, interval: 500, strikes: 3}, configured_hosts: [{"example.com", 443}], ifname: "wlan0", inspector: %{}, ping_list: [], status: :unavailable})
    (vintage_net 0.11.4) lib/vintage_net/connectivity/internet_checker.ex:69: VintageNet.Connectivity.InternetChecker.handle_info/2
    (stdlib 3.17) gen_server.erl:695: :gen_server.try_dispatch/4
    (stdlib 3.17) gen_server.erl:771: :gen_server.handle_msg/6
    (stdlib 3.17) proc_lib.erl:226: :proc_lib.init_p_do_apply/3
```
