### PR TITLE
Explicitly list how to get scanned wifi points in docs

### DIFF
--- a/lib/vintage_net.ex
+++ b/lib/vintage_net.ex
@@ -315,9 +315,12 @@ defmodule VintageNet do
   Initiate an access point scan on a wireless interface
 
   The scan results are posted asynchronously to the `["interface", ifname, "wifi", "access_points"]`
-  property as they come in. It appears that there's some variation in how scanning
-  is implemented on WiFi adapters. One strategy that seems to work is to call `scan/1` every
-  10 seconds or so while prompting a user to pick a WiFi network.
+  property as they come in. After waiting a second or two they can be fetched via
+  `VintageNet.get(["interface", ifname, "wifi", "access_points"])`.
+
+  It appears that there's some variation in how scanning is implemented on WiFi adapters. One
+  strategy that seems to work is to call `scan/1` every 10 seconds or so while prompting a user to
+  pick a WiFi network.
 
   This is a utility function for calling the `:scan` ioctl.
   """


### PR DESCRIPTION
For someone unfamiliar with VintageNet it previously wasn't clear how to get the scanned wifi access points