### PR TITLE
More error output when command runner error fails

### DIFF
--- a/lib/vintage_net/interface/command_runner.ex
+++ b/lib/vintage_net/interface/command_runner.ex
@@ -44,8 +44,13 @@ defmodule VintageNet.Interface.CommandRunner do
       {_, 0} ->
         :ok
 
-      {_, not_zero} ->
-        Logger.error("Nonzero exit from #{command}, #{inspect(args)}: #{not_zero}")
+      {err, not_zero} ->
+        Logger.error("""
+        Nonzero exit from #{command}, #{inspect(args)}: #{not_zero}
+
+        #{inspect(err)}
+        """)
+
         {:error, :non_zero_exit}
     end
   end


### PR DESCRIPTION
This changes the error logged when a command fails to include the stderr message along with the exit code. This will be more helpful in trying to identify command failure reasons