### PR TITLE
Allow absolute path executables for commands

### DIFF
--- a/lib/vintage_net/command.ex
+++ b/lib/vintage_net/command.ex
@@ -47,6 +47,16 @@ defmodule VintageNet.Command do
     )
   end
 
+  defp find_executable("/" <> _ = path) do
+    # User supplied the absolute path so
+    # just check that it exists
+    if File.exists?(path) do
+      {:ok, path}
+    else
+      {"'#{path}' not found", 256}
+    end
+  end
+
   # Note that error return value has to be compatible with System.cmd
   defp find_executable(command) do
     paths = String.split(path_env(), ":")

--- a/test/vintage_net/command_test.exs
+++ b/test/vintage_net/command_test.exs
@@ -22,4 +22,9 @@ defmodule VintageNet.CommandTest do
     assert {expected_path <> "\n", 0} == Command.cmd("sh", ["-c", "echo $PATH"])
     assert {expected_path <> "\n", 0} == Command.muon_cmd("sh", ["-c", "echo $PATH"])
   end
+
+  test "full path executable" do
+    assert {"hello\n", 0} = Command.muon_cmd("/bin/sh", ["-c", "echo hello"])
+    assert {_reason, 256} = Command.muon_cmd("/bin/does-not-exist", ["-c", "echo hello"])
+  end
 end


### PR DESCRIPTION
VintageNet currently expects the executable of a command in the RawConfig to be relative in the PATH. However, some cases you might need to use a binary compiled with your library (i.e `vintage_net_wireguard` and meshing with `vintage_net_wifi`) and want to provide the absolute path to an executable. This change allows you do to that.

You might say _"Well Jon, why don't you just edit the PATH?"_ - Good question. The answer is that VintageNet sets a default path which covers most of the cases. Expecting an altered PATH from a library that depends on VintageNet means the user of the library needs to be expected to set `config :vintage_net, :path` in their library for the library which depends on VintageNet. Instead its easier to do a sanity check on the "command" and consider it an absolute path if it starts with `/`