### PR TITLE
Expose current name server list

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
       - <<: *install_system_deps
       - restore_cache:
           keys:
-            - v2-mix-cache-{{ checksum "mix.lock" }}
+            - v3-mix-cache-{{ checksum "mix.lock" }}
       - run: mix deps.get
       - run: mix test --exclude requires_ipv6
       - run: mix format --check-formatted
@@ -40,7 +40,7 @@ jobs:
       - run: mix dialyzer
       - run: mix coveralls.circle || true
       - save_cache:
-          key: v2-mix-cache-{{ checksum "mix.lock" }}
+          key: v3-mix-cache-{{ checksum "mix.lock" }}
           paths:
             - _build/plts
 

--- a/README.md
+++ b/README.md
@@ -332,6 +332,7 @@ Property               | Values           | Description
  --------------------- | ---------------- | -----------
 `available_interfaces` | `[eth0, ...]`    | Currently available network interfaces in priority order. E.g., the first one is used by default
 `connection`           | `:disconnected`, `:lan`, `:internet` | The overall network connection status. This is the best status of all interfaces.
+`name_servers`         | `[%{address: ..., from: []}]` | Name server addresses and where VintageNet learned about them
 
 ### Common network interface properties
 

--- a/docs/notes/LTE.md
+++ b/docs/notes/LTE.md
@@ -74,7 +74,7 @@ connect "/usr/sbin/chat -v -f /etc/chatscripts/twilio"
 # Disables the default behaviour when no local IP address is specified, which is to determine (if possible) the local IP address from the hostname. With this option, the peer will have to supply the local IP address during IPCP negotiation (unless it specified explicitly on the command line or in an options file).
 noipdefault
 
-# Ask the peer for up to 2 DNS server addresses. The addresses supplied by the peer (if any) are passed to the /etc/ppp/ip-up script in the environment variables DNS1 and DNS2, and the environment variable USEPEERDNS will be set to 1. In addition, pppd will create an /etc/ppp/resolv.conf file containing one or two nameserver lines with the address(es) supplied by the peer.
+# Ask the peer for up to 2 DNS server addresses. The addresses supplied by the peer (if any) are passed to the /etc/ppp/ip-up script in the environment variables DNS1 and DNS2, and the environment variable USEPEERDNS will be set to 1. In addition, pppd will create an /etc/ppp/resolv.conf file containing one or two `nameserver` lines with the address(es) supplied by the peer.
 
 usepeerdns
 

--- a/test/vintage_net/resolver/resolv_conf_test.exs
+++ b/test/vintage_net/resolver/resolv_conf_test.exs
@@ -116,7 +116,7 @@ defmodule VintageNet.Resolver.ResolvConfTest do
     assert to_resolvconf(input) == output
   end
 
-  test "additional nameservers" do
+  test "additional name servers" do
     input = %{
       "eth0" => %{domain: "example.com", name_servers: [{8, 8, 8, 8}, {1, 1, 1, 1}]}
     }
@@ -133,7 +133,7 @@ defmodule VintageNet.Resolver.ResolvConfTest do
     assert to_resolvconf(input, [{1, 1, 1, 1}, {8, 8, 4, 4}]) == output
   end
 
-  test "global nameservers are always first" do
+  test "global name servers are always first" do
     additional_name_servers = [{8, 8, 8, 8}, {1, 1, 1, 1}]
 
     input = %{
@@ -152,5 +152,24 @@ defmodule VintageNet.Resolver.ResolvConfTest do
     """
 
     assert to_resolvconf(input, additional_name_servers) == output
+  end
+
+  test "to_name_server_list/2" do
+    additional_name_servers = [{8, 8, 8, 8}, {1, 1, 1, 1}]
+
+    input = %{
+      "eth0" => %{name_servers: [{4, 4, 4, 4}, {3, 3, 3, 3}, {8, 8, 8, 8}]},
+      "eth1" => %{name_servers: [{4, 4, 4, 4}, {1, 1, 1, 1}, {2, 2, 2, 2}]}
+    }
+
+    output = [
+      %{address: {8, 8, 8, 8}, from: [:global, "eth0"]},
+      %{address: {1, 1, 1, 1}, from: [:global, "eth1"]},
+      %{address: {4, 4, 4, 4}, from: ["eth0", "eth1"]},
+      %{address: {2, 2, 2, 2}, from: ["eth1"]},
+      %{address: {3, 3, 3, 3}, from: ["eth0"]}
+    ]
+
+    assert ResolvConf.to_name_server_list(input, additional_name_servers) == output
   end
 end

--- a/test/vintage_net_test.exs
+++ b/test/vintage_net_test.exs
@@ -219,7 +219,11 @@ defmodule VintageNetTest do
     assert [{["available_interfaces"], []}] ==
              VintageNet.match(["available_interfaces"])
 
-    assert [{["available_interfaces"], []}, {["connection"], :disconnected}] ==
+    assert [
+             {["available_interfaces"], []},
+             {["connection"], :disconnected},
+             {["name_servers"], []}
+           ] ==
              VintageNet.match([:_])
   end
 


### PR DESCRIPTION
This adds a new property, `"name_servers"`, so that VintageNet users can
easily get the list of name servers. Each name server is in a map with
its address and where it was defined. It's possible that port numbers
and other name server information is exposed in the future and that's
why this isn't a simple list of IP addresses.
    
Other changes in this commit:
    
1. VintageNet spells name server as two words like Wikipedia does. Any
   one-word versions were changed for consistency.
2. Remove the state struct in `NameResolver` to be consistent with other
   Nerves code that has moved away from using state structs.
3. Use `start_supervised!/1` instead of raw calls to `start_link/2` in
   tests.
4. Change `"global"` to an atom for when a name server is provided in
   the VintageNet configuration. Now that the API is public, it seems
   better to use an atom rather than accidentally conflict with an
   ifname of `"global"` (if that ever happens).