### PR TITLE
Use the term MFArgs for MF-arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ udhcpc_handler     | Module for handling notifications from `udhcpc`
 resolvconf         | Path to `/etc/resolv.conf`
 persistence        | Module for persisting network configurations
 persistence_dir    | Path to a directory for storing persisted configurations
-persistence_secret | A 16-byte secret or an MFA for getting a secret
+persistence_secret | A 16-byte secret or a function or MFArgs (module, function, arguments tuple) for getting a secret
 internet_host_list | IP address or hostnames and ports to try to connect to for checking Internet connectivity. Defaults to a list of large public DNS providers. E.g., `[{{1, 1, 1, 1}, 53}]`.
 regulatory_domain  | ISO 3166-1 alpha-2 country (`00` for global, `US`, etc.)
 additional_name_servers     | List of DNS servers to be used in addition to any supplied by an interface. E.g., `[{1, 1, 1, 1}, {8, 8, 8, 8}]`

--- a/lib/vintage_net/interface/command_runner.ex
+++ b/lib/vintage_net/interface/command_runner.ex
@@ -7,9 +7,9 @@ defmodule VintageNet.Interface.CommandRunner do
 
   * `{:run, command, args}` - Run a system command
   * `{:run_ignore_exit, command, args}` - Same as `:run`, but without the exit status check
-  * `{:fun, module, function_name, args}` - Run a function by MFA
-  * `{:fun, fun}` - Run a function. Using the MFA form is preferred since it's
-                    easier to verfiy in unit tests.
+  * `{:fun, module, function_name, args}` - Run a function by MFArgs
+  * `{:fun, fun}` - Run a function. Using the MFArgs form is preferred since it's
+                    easier to verify in unit tests.
 
   CommandRunner also implements RawConfig's file creation and
   cleanup logic.

--- a/lib/vintage_net/persistence/flat_file.ex
+++ b/lib/vintage_net/persistence/flat_file.ex
@@ -118,8 +118,8 @@ defmodule VintageNet.Persistence.FlatFile do
 
   defp secret_key() do
     case Application.get_env(:vintage_net, :persistence_secret) do
-      {m, f, a} ->
-        apply(m, f, a)
+      {m, f, args} ->
+        apply(m, f, args)
 
       f when is_function(f, 0) ->
         f.()

--- a/test/vintage_net/persistence/flat_file_test.exs
+++ b/test/vintage_net/persistence/flat_file_test.exs
@@ -84,7 +84,7 @@ defmodule VintageNet.Persistence.FlatFileTest do
     Application.put_env(:vintage_net, :persistence_secret, original_key)
   end
 
-  test "using an MFA for getting the secret key" do
+  test "using an MFArgs for getting the secret key" do
     original_key = Application.get_env(:vintage_net, :persistence_secret)
 
     Application.put_env(:vintage_net, :persistence_secret, {__MODULE__, :get_secret, []})


### PR DESCRIPTION
Turns out that MFA is module, function, arity. The other places I've
seen module, function, arguments, the term MFArgs has been used. If
nothing else, if this ever gets typespecs, it couldn't use `mfa()`
without a warning.
