### PR TITLE
Add raw config from interface bound events to PropertyTable

### DIFF
--- a/lib/vintage_net/os_event_dispatcher.ex
+++ b/lib/vintage_net/os_event_dispatcher.ex
@@ -21,15 +21,15 @@ defmodule VintageNet.OSEventDispatcher do
 
     case op do
       "deconfig" ->
-        PropertyTable.delete(VintageNet, ["interface", ifname, "raw_config"])
+        PropertyTable.delete(VintageNet, ["interface", ifname, "dhcp_options"])
 
       "bound" ->
-        raw_config =
+        dhcp_options =
           info
           |> Enum.filter(fn {k, _} -> k != String.upcase(k) end)
           |> Enum.into(%{})
 
-        PropertyTable.put(VintageNet, ["interface", ifname, "raw_config"], raw_config)
+        PropertyTable.put(VintageNet, ["interface", ifname, "dhcp_options"], dhcp_options)
 
       _ ->
         :ok

--- a/lib/vintage_net/os_event_dispatcher.ex
+++ b/lib/vintage_net/os_event_dispatcher.ex
@@ -24,7 +24,11 @@ defmodule VintageNet.OSEventDispatcher do
         PropertyTable.delete(VintageNet, ["interface", ifname, "raw_config"])
 
       "bound" ->
-        raw_config = info |> Map.filter(fn {k, _} -> k != String.upcase(k) end)
+        raw_config =
+          info
+          |> Enum.filter(fn {k, _} -> k != String.upcase(k) end)
+          |> Enum.into(%{})
+
         PropertyTable.put(VintageNet, ["interface", ifname, "raw_config"], raw_config)
 
       _ ->

--- a/lib/vintage_net/os_event_dispatcher.ex
+++ b/lib/vintage_net/os_event_dispatcher.ex
@@ -19,6 +19,18 @@ defmodule VintageNet.OSEventDispatcher do
       when op in ["deconfig", "leasefail", "nak", "renew", "bound"] do
     handler = Application.get_env(:vintage_net, :udhcpc_handler)
 
+    case op do
+      "deconfig" ->
+        PropertyTable.delete(VintageNet, ["interface", ifname, "raw_config"])
+
+      "bound" ->
+        raw_config = info |> Map.filter(fn {k, _} -> k != String.upcase(k) end)
+        PropertyTable.put(VintageNet, ["interface", ifname, "raw_config"], raw_config)
+
+      _ ->
+        :ok
+    end
+
     new_info = info |> key_to_list("dns") |> key_to_list("router")
 
     apply(handler, String.to_atom(op), [ifname, new_info])

--- a/test/vintage_net/os_event_dispatcher_test.exs
+++ b/test/vintage_net/os_event_dispatcher_test.exs
@@ -1,10 +1,34 @@
 defmodule VintageNet.OSEventDispatcherTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: false
 
   import ExUnit.CaptureLog
 
   alias VintageNet.OSEventDispatcher
   alias VintageNetTest.{CapturingUdhcpcHandler, CapturingUdhcpdHandler}
+
+  test "os event dispatcher writes raw config to property table" do
+    info = %{
+      "dns" => "192.168.1.149 1.1.1.1 9.9.9.9",
+      "domain" => "localdomain",
+      "interface" => "eth0",
+      "ip" => "192.168.1.245",
+      "lease" => "86400",
+      "mask" => "24",
+      "ntpsrv" => "192.168.1.149",
+      "opt53" => "05",
+      "router" => "192.168.1.1",
+      "serverid" => "192.168.1.1",
+      "subnet" => "255.255.255.0"
+    }
+
+    OSEventDispatcher.dispatch(["bound"], info)
+    raw_config = PropertyTable.get(VintageNet, ["interface", "eth0", "raw_config"])
+    assert raw_config == info
+
+    OSEventDispatcher.dispatch(["deconfig"], info)
+    raw_config = PropertyTable.get(VintageNet, ["interface", "eth0", "raw_config"])
+    assert raw_config == nil
+  end
 
   test "udhcpc handler notifies Elixir" do
     for op <- [:deconfig, :leasefail, :nak, :renew, :bound] do

--- a/test/vintage_net/os_event_dispatcher_test.exs
+++ b/test/vintage_net/os_event_dispatcher_test.exs
@@ -22,12 +22,12 @@ defmodule VintageNet.OSEventDispatcherTest do
     }
 
     OSEventDispatcher.dispatch(["bound"], info)
-    raw_config = PropertyTable.get(VintageNet, ["interface", "eth0", "raw_config"])
-    assert raw_config == info
+    dhcp_options = PropertyTable.get(VintageNet, ["interface", "eth0", "dhcp_options"])
+    assert dhcp_options == info
 
     OSEventDispatcher.dispatch(["deconfig"], info)
-    raw_config = PropertyTable.get(VintageNet, ["interface", "eth0", "raw_config"])
-    assert raw_config == nil
+    dhcp_options = PropertyTable.get(VintageNet, ["interface", "eth0", "dhcp_options"])
+    assert dhcp_options == nil
   end
 
   test "udhcpc handler notifies Elixir" do


### PR DESCRIPTION
Fixes #440

I tried to do minimal changes, happy to revisit or optimize the code as you see fit.

I decided to name the property `raw_config` since I decided to skip some processing that is done before `udhcpc_handler` is called. Specifically the `info |> key_to_list("dns") |> key_to_list("router")`   updates to the info map.