### PR TITLE
Report DHCP options via the property table

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,6 +350,7 @@ Property      | Values              | Description
 `lower_up`    | `true` or `false`   | This indicates whether the physical layer is "up". E.g., a cable is connected or WiFi associated
 `mac_address` | "11:22:33:44:55:66" | The interface's MAC address as a string
 `addresses`   | [address_info]      | This is a list of all of the addresses assigned to this interface
+`dhcp_options` | `%{...}`           | When DHCP is in use, the processed response information and options is stored here. See `t:VintageNet.DHCP.Options.t/0`
 
 Specific types of interfaces provide more parameters.
 

--- a/lib/vintage_net/dhcp/options.ex
+++ b/lib/vintage_net/dhcp/options.ex
@@ -1,0 +1,181 @@
+defmodule VintageNet.DHCP.Options do
+  @moduledoc """
+  DHCP Options
+  """
+
+  alias VintageNet.IP
+  require Logger
+
+  @typedoc """
+  A map of options and other information reported by udhcpc
+
+  Here's an example:
+
+  ```elixir
+  %{
+    broadcast: {192, 168, 7, 255},
+    dns: {192, 168, 7, 1},
+    domain: "hunleth.lan",
+    hostname: "nerves-9780",
+    ip: {192, 168, 7, 190},
+    lease: 86400,
+    mask: 24,
+    router: {192, 168, 7, 1},
+    serverid: {192, 168, 7, 1},
+    siaddr: {192, 168, 7, 1},
+    subnet: {255, 255, 255, 0}
+  }
+  ```
+  """
+  @type t() :: %{
+          optional(:ip) => :inet.ip_address(),
+          optional(:mask) => non_neg_integer(),
+          optional(:siaddr) => :inet.ip_address(),
+          optional(:subnet) => :inet.ip_address(),
+          optional(:timezone) => String.t(),
+          optional(:router) => [:inet.ip_address()],
+          optional(:dns) => [:inet.ip_address()],
+          optional(:lprsrv) => [:inet.ip_address()],
+          optional(:hostname) => String.t(),
+          optional(:bootsize) => String.t(),
+          optional(:domain) => String.t(),
+          optional(:swapsrv) => :inet.ip_address(),
+          optional(:rootpath) => String.t(),
+          optional(:ipttl) => non_neg_integer(),
+          optional(:mtu) => non_neg_integer(),
+          optional(:broadcast) => :inet.ip_address(),
+          optional(:routes) => [:inet.ip_address()],
+          optional(:nisdomain) => String.t(),
+          optional(:nissrv) => [:inet.ip_address()],
+          optional(:ntpsrv) => [:inet.ip_address()],
+          optional(:wins) => String.t(),
+          optional(:lease) => non_neg_integer(),
+          optional(:serverid) => :inet.ip_address(),
+          optional(:message) => String.t(),
+          optional(:renewal_time) => non_neg_integer(),
+          optional(:rebind_time) => non_neg_integer(),
+          optional(:vendor) => String.t(),
+          optional(:tftp) => String.t(),
+          optional(:bootfile) => String.t(),
+          optional(:userclass) => String.t(),
+          optional(:tzstr) => String.t(),
+          optional(:tzdbstr) => String.t(),
+          optional(:search) => String.t(),
+          optional(:sipsrv) => String.t(),
+          optional(:staticroutes) => [:inet.ip_address()],
+          optional(:vlanid) => String.t(),
+          optional(:vlanpriority) => non_neg_integer(),
+          optional(:pxeconffile) => String.t(),
+          optional(:pxepathprefix) => String.t(),
+          optional(:reboottime) => String.t(),
+          optional(:ip6rd) => String.t(),
+          optional(:msstaticroutes) => String.t(),
+          optional(:wpad) => String.t()
+        }
+
+  # Extract and translate udhcpc environment variables to DHCP options
+  @doc false
+  @spec udhcpc_to_options(%{String.t() => String.t()}) :: t()
+  def udhcpc_to_options(info) do
+    info
+    |> Map.new(&transform_udhcpc_option/1)
+    |> Map.delete(:discard)
+  end
+
+  # udhcpc passes DHCP options via environment variables and there's a lot of noise.
+  # Transform known keys to atoms and mark unknown or unsupported ones as `:discard`
+  defp transform_udhcpc_option({k, v}) do
+    # See https://elixir.bootlin.com/busybox/1.35.0/source/networking/udhcp/common.c#L97
+    # See https://www.rfc-editor.org/rfc/rfc2132 for descriptions
+    udhcpc_option_map = %{
+      # DHCP fields
+      "ip" => {:ip, &IP.ip_to_tuple/1},
+      "mask" => {:mask, &parse_int/1},
+      "siaddr" => {:siaddr, &IP.ip_to_tuple/1},
+      # DHCP options
+      "subnet" => {:subnet, &IP.ip_to_tuple/1},
+      "timezone" => {:timezone, &identity/1},
+      "router" => {:router, &parse_ip_list/1},
+      # "opt4" => :timesrv,
+      # "opt5" => :namesrv,
+      "dns" => {:dns, &parse_ip_list/1},
+      # "opt7" => :logsrv,
+      # "opt8" => :cookiesrv,
+      "lprsrv" => {:lprsrv, &parse_ip_list/1},
+      "hostname" => {:hostname, &identity/1},
+      "bootsize" => {:bootsize, &identity/1},
+      "domain" => {:domain, &identity/1},
+      "swapsrv" => {:swapsrv, &IP.ip_to_tuple/1},
+      "rootpath" => {:rootpath, &identity/1},
+      "ipttl" => {:ipttl, &parse_int/1},
+      "mtu" => {:mtu, &parse_int/1},
+      "broadcast" => {:broadcast, &IP.ip_to_tuple/1},
+      "routes" => {:routes, &parse_ip_list/1},
+      "nisdomain" => {:nisdomain, &identity/1},
+      "nissrv" => {:nissrv, &parse_ip_list/1},
+      "ntpsrv" => {:ntpsrv, &parse_ip_list/1},
+      "wins" => {:wins, &identity/1},
+      "lease" => {:lease, &parse_int/1},
+      "serverid" => {:serverid, &IP.ip_to_tuple/1},
+      "message" => {:message, &identity/1},
+      "opt58" => {:renewal_time, &parse_hex/1},
+      "opt59" => {:rebind_time, &parse_hex/1},
+      "vendor" => {:vendor, &identity/1},
+      "tftp" => {:tftp, &identity/1},
+      "bootfile" => {:bootfile, &identity/1},
+      "opt77" => {:userclass, &identity/1},
+      "tzstr" => {:tzstr, &identity/1},
+      "tzdbstr" => {:tzdbstr, &identity/1},
+      "search" => {:search, &identity/1},
+      "sipsrv" => {:sipsrv, &identity/1},
+      "staticroutes" => {:staticroutes, &parse_ip_list/1},
+      "vlanid" => {:vlanid, &identity/1},
+      "vlanpriority" => {:vlanpriority, &parse_int/1},
+      "pxeconffile" => {:pxeconffile, &identity/1},
+      "pxepathprefix" => {:pxepathprefix, &identity/1},
+      "reboottime" => {:reboottime, &identity/1},
+      "ip6rd" => {:ip6rd, &identity/1},
+      "msstaticroutes" => {:msstaticroutes, &identity/1},
+      "wpad" => {:wpad, &identity/1}
+      # opt50 is used to request a client IP and used internally by udhcpc, so skip.
+      # opt53 is the message type, so it's not an option
+      # opt57 is the max message length, so it's not an option
+      # See https://elixir.bootlin.com/busybox/1.35.0/source/networking/udhcp/common.c#L83
+    }
+
+    with {:ok, {key, parser}} <- Map.fetch(udhcpc_option_map, k),
+         {:ok, result} <- parser.(v) do
+      {key, result}
+    else
+      _error -> {:discard, nil}
+    end
+  end
+
+  defp summarize_ok_tuples(ok_tuples, results \\ [])
+  defp summarize_ok_tuples([], results), do: {:ok, Enum.reverse(results)}
+  defp summarize_ok_tuples([{:ok, v} | rest], acc), do: summarize_ok_tuples(rest, [v | acc])
+  defp summarize_ok_tuples([{:error, _} = error | _rest], _), do: error
+
+  defp parse_ip_list(str) do
+    str
+    |> String.split(" ", trim: true)
+    |> Enum.map(&IP.ip_to_tuple/1)
+    |> summarize_ok_tuples()
+  end
+
+  defp parse_int(str) do
+    case Integer.parse(str) do
+      {v, ""} -> {:ok, v}
+      _ -> {:error, "Expecting integer, got #{str}."}
+    end
+  end
+
+  defp parse_hex(str) do
+    case Integer.parse(str, 16) do
+      {v, ""} -> {:ok, v}
+      _ -> {:error, "Expecting hex, got #{str}."}
+    end
+  end
+
+  defp identity(str), do: {:ok, str}
+end

--- a/lib/vintage_net/name_resolver.ex
+++ b/lib/vintage_net/name_resolver.ex
@@ -54,7 +54,7 @@ defmodule VintageNet.NameResolver do
 
   This replaces any entries in the `/etc/resolv.conf` for this interface.
   """
-  @spec setup(String.t(), String.t() | nil, [VintageNet.any_ip_address()]) :: :ok
+  @spec setup(String.t(), String.t() | nil, [:inet.ip_address()]) :: :ok
   def setup(ifname, domain, name_servers) do
     GenServer.call(__MODULE__, {:setup, ifname, domain, name_servers})
   end
@@ -99,8 +99,7 @@ defmodule VintageNet.NameResolver do
 
   @impl GenServer
   def handle_call({:setup, ifname, domain, name_servers}, _from, state) do
-    servers = Enum.map(name_servers, &IP.ip_to_tuple!/1)
-    ifentry = %{domain: domain, name_servers: servers}
+    ifentry = %{domain: domain, name_servers: name_servers}
 
     state = %{state | entries: Map.put(state.entries, ifname, ifentry)}
     refresh(state)

--- a/lib/vintage_net/os_event_dispatcher.ex
+++ b/lib/vintage_net/os_event_dispatcher.ex
@@ -19,6 +19,22 @@ defmodule VintageNet.OSEventDispatcher do
       when op in ["deconfig", "leasefail", "nak", "renew", "bound"] do
     handler = Application.get_env(:vintage_net, :udhcpc_handler)
 
+    case op do
+      "deconfig" ->
+        PropertyTable.delete(VintageNet, ["interface", ifname, "dhcp_options"])
+
+      "bound" ->
+        dhcp_options =
+          info
+          |> Enum.filter(fn {k, _} -> k != String.upcase(k) end)
+          |> Enum.into(%{})
+
+        PropertyTable.put(VintageNet, ["interface", ifname, "dhcp_options"], dhcp_options)
+
+      _ ->
+        :ok
+    end
+
     new_info = info |> key_to_list("dns") |> key_to_list("router")
 
     apply(handler, String.to_atom(op), [ifname, new_info])

--- a/lib/vintage_net/os_event_dispatcher/udhcpc_handler.ex
+++ b/lib/vintage_net/os_event_dispatcher/udhcpc_handler.ex
@@ -1,77 +1,51 @@
 defmodule VintageNet.OSEventDispatcher.UdhcpcHandler do
-  @moduledoc """
-  A behaviour for handling notifications from udhcpc
+  @moduledoc false
 
-  ## Example
+  # A private behaviour for handling notifications from udhcpc
+  #
+  # ## Example
+  #
+  # ```elixir
+  # defmodule MyApp.UdhcpcHandler do
+  #   @behaviour VintageNet.OSEventDispatcher.UdhcpcHandler
+  #
+  #   @impl VintageNet.OSEventDispatcher.UdhcpcHandler
+  #   def deconfig(ifname, data) do
+  #     ...
+  #   end
+  # end
+  # ```
+  #
+  # To have VintageNet invoke it, add the following to your `config.exs`:
+  #
+  # ```elixir
+  # config :vintage_net, udhcpc_handler: MyApp.UdhcpcHandler
+  # ```
 
-  ```elixir
-  defmodule MyApp.UdhcpcHandler do
-    @behaviour VintageNet.OSEventDispatcher.UdhcpcHandler
-
-    @impl VintageNet.OSEventDispatcher.UdhcpcHandler
-    def deconfig(ifname, data) do
-      ...
-    end
-  end
-  ```
-
-  To have VintageNet invoke it, add the following to your `config.exs`:
-
-  ```elixir
-  config :vintage_net, udhcpc_handler: MyApp.UdhcpcHandler
-  ```
-  """
-
-  @typedoc """
-  Update data is the unmodified environment variable strings from udhcpc
-
-  The following is an example of update data, but it really depends
-  on what udhcpc wants to send:
-
-  ```elixir
-  %{
-    "broadcast" => "192.168.7.255",
-    "dns" => "192.168.7.1",
-    "domain" => "hunleth.lan",
-    "hostname" => "nerves-9780",
-    "interface" => "eth0",
-    "ip" => "192.168.7.190",
-    "lease" => "86400",
-    "mask" => "24",
-    "opt53" => "05",
-    "opt58" => "0000a8c0",
-    "opt59" => "00012750",
-    "router" => "192.168.7.1",
-    "serverid" => "192.168.7.1",
-    "siaddr" => "192.168.7.1",
-    "subnet" => "255.255.255.0"
-  }
-  ```
-  """
-  @type update_data :: %{String.t() => String.t()}
+  alias VintageNet.DHCP.Options
 
   @doc """
   Deconfigure the specified interface
   """
-  @callback deconfig(VintageNet.ifname(), update_data()) :: :ok
+  @callback deconfig(VintageNet.ifname(), Options.t()) :: :ok
 
   @doc """
   Handle a failure to get a lease
   """
-  @callback leasefail(VintageNet.ifname(), update_data()) :: :ok
+  @callback leasefail(VintageNet.ifname(), Options.t()) :: :ok
 
   @doc """
   Handle a DHCP NAK
   """
-  @callback nak(VintageNet.ifname(), update_data()) :: :ok
+  @callback nak(VintageNet.ifname(), Options.t()) :: :ok
 
   @doc """
   Handle the renewal of a DHCP lease
   """
-  @callback renew(VintageNet.ifname(), update_data()) :: :ok
+  @callback renew(VintageNet.ifname(), Options.t()) :: :ok
 
   @doc """
   Handle an assignment from the DHCP server
   """
-  @callback bound(VintageNet.ifname(), update_data()) :: :ok
+  @callback bound(VintageNet.ifname(), Options.t()) :: :ok
 end

--- a/lib/vintage_net/os_event_dispatcher/udhcpd_handler.ex
+++ b/lib/vintage_net/os_event_dispatcher/udhcpd_handler.ex
@@ -1,26 +1,26 @@
 defmodule VintageNet.OSEventDispatcher.UdhcpdHandler do
-  @moduledoc """
-  A behaviour for handling notifications from udhcpd
+  @moduledoc false
 
-  ## Example
-
-  ```elixir
-  defmodule MyApp.UdhcpdHandler do
-    @behaviour VintageNet.OSEventDispatcher.UdhcpdHandler
-
-    @impl VintageNet.OSEventDispatcher.UdhcpdHandler
-    def lease_update(ifname, report_data) do
-      ...
-    end
-  end
-  ```
-
-  To have VintageNet invoke it, add the following to your `config.exs`:
-
-  ```elixir
-  config :vintage_net, udhcpd_handler: MyApp.UdhcpdHandler
-  ```
-  """
+  # A private behaviour for handling notifications from udhcpd
+  #
+  # ## Example
+  #
+  # ```elixir
+  # defmodule MyApp.UdhcpdHandler do
+  #   @behaviour VintageNet.OSEventDispatcher.UdhcpdHandler
+  #
+  #   @impl VintageNet.OSEventDispatcher.UdhcpdHandler
+  #   def lease_update(ifname, report_data) do
+  #     ...
+  #   end
+  # end
+  # ```
+  #
+  # To have VintageNet invoke it, add the following to your `config.exs`:
+  #
+  # ```elixir
+  # config :vintage_net, udhcpd_handler: MyApp.UdhcpdHandler
+  # ```
 
   @doc """
   The DHCP lease file was updated

--- a/test/vintage_net/dhcp/options_test.exs
+++ b/test/vintage_net/dhcp/options_test.exs
@@ -1,0 +1,39 @@
+defmodule VintageNet.DHCP.OptionsTest do
+  use ExUnit.Case, async: true
+
+  alias VintageNet.DHCP.Options
+
+  test "translate typical options correctly" do
+    info = %{
+      "dns" => "192.168.1.149 1.1.1.1 9.9.9.9",
+      "domain" => "localdomain",
+      "interface" => "eth0",
+      "ip" => "192.168.1.245",
+      "lease" => "86400",
+      "mask" => "24",
+      "ntpsrv" => "192.168.1.149",
+      "opt53" => "05",
+      "opt58" => "0000a8c0",
+      "opt59" => "00012750",
+      "router" => "192.168.1.1",
+      "serverid" => "192.168.1.1",
+      "subnet" => "255.255.255.0"
+    }
+
+    expected_options = %{
+      dns: [{192, 168, 1, 149}, {1, 1, 1, 1}, {9, 9, 9, 9}],
+      domain: "localdomain",
+      ip: {192, 168, 1, 245},
+      lease: 86400,
+      mask: 24,
+      ntpsrv: [{192, 168, 1, 149}],
+      router: [{192, 168, 1, 1}],
+      rebind_time: 75600,
+      renewal_time: 43200,
+      serverid: {192, 168, 1, 1},
+      subnet: {255, 255, 255, 0}
+    }
+
+    assert expected_options == Options.udhcpc_to_options(info)
+  end
+end


### PR DESCRIPTION
This pulls in #441 and updates it to decode the DHCP options. This turned out to
be convenient for use with VintageNet internally as well and opens up some
future improvements.

DHCP options continue to use the `udhcpc` names which looks a little strange,
but is possibly easier to trace if there's an issue. Values are all processed to
strings, numbers, IP addresses or IP address lists depending on their type. This
saves users of the DHCP options from having to do this themselves.

Here's an example:

```elixir
iex(6)> VintageNet.get(["interface", "wlan0", "dhcp_options"])
%{
  broadcast: {192, 168, 99, 255},
  dns: [{192, 168, 99, 1}],
  domain: "my.lan",
  hostname: "mydevice",
  ip: {192, 168, 99, 232},
  lease: 86400,
  mask: 24,
  rebind_time: 75600,
  renewal_time: 43200,
  router: [{192, 168, 99, 1}],
  serverid: {192, 168, 99, 1},
  siaddr: {192, 168, 99, 1},
  subnet: {255, 255, 255, 0}
}
```

- Add DHCP config from interface bound events to PropertyTable
- Elevate DHCP options to their own module
