### PR TITLE
Remove State modules

### DIFF
--- a/lib/vintage_net/interfaces_monitor.ex
+++ b/lib/vintage_net/interfaces_monitor.ex
@@ -12,12 +12,8 @@ defmodule VintageNet.InterfacesMonitor do
 
   alias VintageNet.InterfacesMonitor.{HWPath, Info}
 
-  defmodule State do
-    @moduledoc false
-
-    defstruct port: nil,
-              interface_info: %{}
-  end
+  defstruct port: nil,
+            interface_info: %{}
 
   @spec start_link(any()) :: GenServer.on_start()
   def start_link(args) do
@@ -50,11 +46,11 @@ defmodule VintageNet.InterfacesMonitor do
             :exit_status
           ])
 
-        {:ok, %State{port: port}}
+        {:ok, %__MODULE__{port: port}}
 
       false ->
         # This is only done for testing on OSX
-        {:ok, %State{}}
+        {:ok, %__MODULE__{}}
     end
   end
 

--- a/lib/vintage_net/power_manager/pm_control.ex
+++ b/lib/vintage_net/power_manager/pm_control.ex
@@ -33,21 +33,17 @@ defmodule VintageNet.PowerManager.PMControl do
 
   @default_watchdog_timeout 60_000
 
-  defmodule State do
-    @moduledoc false
-
-    defstruct [
-      :impl,
-      :impl_args,
-      :impl_state,
-      :ifname,
-      :pm_state,
-      :sm,
-      :timer_id,
-      :timer_ref,
-      :watchdog_timeout
-    ]
-  end
+  defstruct [
+    :impl,
+    :impl_args,
+    :impl_state,
+    :ifname,
+    :pm_state,
+    :sm,
+    :timer_id,
+    :timer_ref,
+    :watchdog_timeout
+  ]
 
   @doc """
   Start up a server
@@ -155,7 +151,7 @@ defmodule VintageNet.PowerManager.PMControl do
 
   @impl GenServer
   def init(opts) do
-    state = %State{
+    state = %__MODULE__{
       impl: opts[:impl],
       impl_args: opts[:impl_args],
       sm: StateMachine.init(),


### PR DESCRIPTION
This is a micro-optimization due to each module taking a short, but
measurable time to find on disk and load.
