### PR TITLE
Fix confusion with dhcpd subnet option

### DIFF
--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -251,7 +251,7 @@ involved. Here is a basic configuration:
     end: "192.168.24.10",
     options: %{
       dns: ["1.1.1.1", "1.0.0.1"],
-      subnet: "192.168.24.255",
+      subnet: "255.255.255.0",
       router: ["192.168.24.1"]
     }
   }

--- a/lib/vintage_net/ip/dhcpd_config.ex
+++ b/lib/vintage_net/ip/dhcpd_config.ex
@@ -22,7 +22,7 @@ defmodule VintageNet.IP.DhcpdConfig do
     * `:router` - IP_LIST
     * `:search` - STRING_LIST - [0x77] search domains
     * `:serverid` - IP (defaults to the interface's IP address)
-    * `:subnet` - IP (as a subnet mask)
+    * `:subnet` or `:netmask` - IP as a subnet mask (`:netmask` is an alias for `:subnet`)
 
   > #### :options {: .info}
   > Options may also be passed in as integers. These are passed directly to the DHCP server
@@ -47,7 +47,7 @@ defmodule VintageNet.IP.DhcpdConfig do
         end: "192.168.24.10",
         options: %{
           dns: ["1.1.1.1", "1.0.0.1"],
-          subnet: "192.168.24.255",
+          netmask: "255.255.255.0",
           router: ["192.168.24.1"]
         }
       }
@@ -112,6 +112,10 @@ defmodule VintageNet.IP.DhcpdConfig do
   end
 
   defp normalize_options(dhcpd_config), do: dhcpd_config
+
+  # Support :netmask as an alias to :subnet in v0.13.2. This makes
+  # the configuration more consistent with `:ipv4` options.
+  defp normalize_option({:netmask, ip}), do: normalize_option({:subnet, ip})
 
   defp normalize_option({ip_option, ip})
        when ip_option in @ip_options do

--- a/test/vintage_net/ip/dhcpd_config_test.exs
+++ b/test/vintage_net/ip/dhcpd_config_test.exs
@@ -34,6 +34,7 @@ defmodule VintageNet.IP.DhcpdConfigTest do
           :mtu => 9216,
           :serverid => {192, 168, 1, 1},
           :hostname => "marshmallow",
+          :subnet => "255.255.255.0",
           0x08 => "01020304"
         }
       }
@@ -58,8 +59,31 @@ defmodule VintageNet.IP.DhcpdConfigTest do
           :hostname => "marshmallow",
           :mtu => 9216,
           :serverid => {192, 168, 1, 1},
+          :subnet => {255, 255, 255, 0},
           8 => "01020304"
         }
+      }
+    }
+
+    assert normalized_config == DhcpdConfig.normalize(config)
+  end
+
+  test "dhcpd netmask is an alias for subnet" do
+    config = %{
+      dhcpd: %{
+        start: "192.168.1.2",
+        end: "192.168.1.100",
+        options: %{
+          netmask: "255.255.255.0"
+        }
+      }
+    }
+
+    normalized_config = %{
+      dhcpd: %{
+        start: {192, 168, 1, 2},
+        end: {192, 168, 1, 100},
+        options: %{subnet: {255, 255, 255, 0}}
       }
     }
 


### PR DESCRIPTION
Busybox calls the DHCP subnet mask option field "subnet" when
configuring it. This is reflected in VintageNet's configuration options
for it since they match one for one.

This cause some confusion on whether the subnet or subnet mask should be
passed. This fixes issues with the documentation and adds `:netmask` as
an alias so that users can make their own code more clear if they want.
