### PR TITLE
Handle all messages sent to InterfacesMonitor

### DIFF
--- a/test/vintage_net/interfaces_monitor_test.exs
+++ b/test/vintage_net/interfaces_monitor_test.exs
@@ -348,7 +348,8 @@ defmodule VintageNet.InterfacesMonitorTest do
 
   defp send_report(report) do
     # Simulate a report coming from C
+    state = :sys.get_state(Process.whereis(VintageNet.InterfacesMonitor))
     encoded_report = :erlang.term_to_binary(report)
-    send(VintageNet.InterfacesMonitor, {:port, {:data, encoded_report}})
+    send(VintageNet.InterfacesMonitor, {state.port, {:data, encoded_report}})
   end
 end


### PR DESCRIPTION
This adds handling for when the interfaces monitor port application
exits. This shouldn't happen, but it has been seen and this logs an
error with the test so that it's easier to read when it happens.

This PR also adds handling for other messages just in case some funny
business is going on with sending messages to the InterfacesMonitor.
