### PR TITLE
Ignore newaddr/deladdr notifications for unknown interfaces

### DIFF
--- a/lib/vintage_net/interfaces_monitor.ex
+++ b/lib/vintage_net/interfaces_monitor.ex
@@ -105,21 +105,37 @@ defmodule VintageNet.InterfacesMonitor do
   end
 
   defp handle_report(state, {:newaddr, ifindex, address_report}) do
-    new_info =
-      get_or_create_info(state, ifindex)
-      |> Info.newaddr(address_report)
-      |> Info.update_address_properties()
+    case Map.fetch(state.interface_info, ifindex) do
+      {:ok, info} ->
+        new_info =
+          info
+          |> Info.newaddr(address_report)
+          |> Info.update_address_properties()
 
-    %{state | interface_info: Map.put(state.interface_info, ifindex, new_info)}
+        %{state | interface_info: Map.put(state.interface_info, ifindex, new_info)}
+
+      :error ->
+        Logger.debug("interfaces_monitor ignoring newaddr for unknown interface #{ifindex}")
+
+        state
+    end
   end
 
   defp handle_report(state, {:deladdr, ifindex, address_report}) do
-    new_info =
-      get_or_create_info(state, ifindex)
-      |> Info.deladdr(address_report)
-      |> Info.update_address_properties()
+    case Map.fetch(state.interface_info, ifindex) do
+      {:ok, info} ->
+        new_info =
+          info
+          |> Info.deladdr(address_report)
+          |> Info.update_address_properties()
 
-    %{state | interface_info: Map.put(state.interface_info, ifindex, new_info)}
+        %{state | interface_info: Map.put(state.interface_info, ifindex, new_info)}
+
+      :error ->
+        Logger.debug("interfaces_monitor ignoring deladdr for unknown interface #{ifindex}")
+
+        state
+    end
   end
 
   defp get_by_ifname(state, ifname) do
@@ -148,17 +164,6 @@ defmodule VintageNet.InterfacesMonitor do
 
         Info.new(ifname, hw_path)
         |> Info.update_present()
-    end
-  end
-
-  defp get_or_create_info(state, ifindex) do
-    case Map.fetch(state.interface_info, ifindex) do
-      {:ok, info} ->
-        info
-
-      _missing ->
-        # Race between address and link notifications?
-        Info.new("__unknown")
     end
   end
 end


### PR DESCRIPTION
Previously, these would be labeled with the "__unknown" network
interface name. This ended up causing more problems since code watching
network interfaces would try to do things with the "__unknown" network.
It also didn't help, the notifications were effectively ignored by
stashing them there and it was impossible to use "__unknwon" since it
could accumulate information from several network interfaces.

The solution in this PR is to just drop the notifications. That doesn't
change behavior for any code listening to real network interfaces. I do
not know of any use of the "__unknown" interface. Messages are logged,
but through my debug I couldn't find a reason to make more than debug
level since I think they're artifacts of asynchronous cleanup of network
interfaces.
