### PR TITLE
Normalize configs on load and save failure reasons

### DIFF
--- a/lib/vintage_net.ex
+++ b/lib/vintage_net.ex
@@ -228,7 +228,7 @@ defmodule VintageNet do
     |> List.keyfind(ifname, 0)
     |> case do
       {^ifname, config} -> config
-      _anything_else -> %{type: VintageNet.Technology.Null}
+      _anything_else -> %{type: VintageNet.Technology.Null, reason: "No default configuration"}
     end
   end
 

--- a/lib/vintage_net/technology.ex
+++ b/lib/vintage_net/technology.ex
@@ -59,4 +59,33 @@ defmodule VintageNet.Technology do
   network.
   """
   @callback check_system(opts :: keyword()) :: :ok | {:error, String.t()}
+
+  @doc """
+  Helper to fetch the Technology implementation from a configuration
+  """
+  @spec module_from_config!(%{:type => module, optional(any) => any}) :: module
+  def module_from_config!(%{type: type}) when is_atom(type) do
+    if Code.ensure_loaded?(type) do
+      type
+    else
+      raise(ArgumentError, """
+      Invalid technology #{inspect(type)}.
+
+      Check the spelling and that you have the dependency that provides it in your mix.exs.
+      See the `vintage_net` docs for examples.
+      """)
+    end
+  end
+
+  def module_from_config!(_missing) do
+    raise(
+      ArgumentError,
+      """
+      Missing :type field.
+
+      This should be set to a network technology. These are provided in other libraries.
+      See the `vintage_net` docs and cookbook for examples.
+      """
+    )
+  end
 end

--- a/lib/vintage_net/technology/null.ex
+++ b/lib/vintage_net/technology/null.ex
@@ -1,22 +1,25 @@
 defmodule VintageNet.Technology.Null do
   @moduledoc """
   An interface with this technology is unconfigured
+
+  If this was due to an error, the reason field will have more information.
   """
   @behaviour VintageNet.Technology
 
   alias VintageNet.Interface.RawConfig
 
-  @null_config %{type: __MODULE__}
+  @impl VintageNet.Technology
+  def normalize(config) do
+    reason = Map.get(config, :reason, "")
+    %{type: __MODULE__, reason: reason}
+  end
 
   @impl VintageNet.Technology
-  def normalize(_config), do: @null_config
-
-  @impl VintageNet.Technology
-  def to_raw_config(ifname, _config \\ %{}, _opts \\ []) do
+  def to_raw_config(ifname, config \\ %{}, _opts \\ []) do
     %RawConfig{
       ifname: ifname,
       type: __MODULE__,
-      source_config: @null_config,
+      source_config: normalize(config),
       required_ifnames: []
     }
   end

--- a/test/vintage_net/application_test.exs
+++ b/test/vintage_net/application_test.exs
@@ -85,4 +85,26 @@ defmodule VintageNet.ApplicationTest do
 
     assert VintageNet.Application.get_config_env() == []
   end
+
+  test "normalization normalizes configs" do
+    {ifname, if_config} = VintageNet.Application.normalize_config(hd(@test_config))
+
+    assert ifname == "bogus1"
+
+    assert if_config == %{
+             type: VintageNetTest.TestTechnology,
+             bogus: 1,
+             normalize_was_called: true
+           }
+  end
+
+  test "normalization gives reasons for unrecoverable configurations errors" do
+    input_config = {"bogus3", %{type: VintageNetTest.BadTechnology, bogus: 3}}
+
+    {ifname, if_config} = VintageNet.Application.normalize_config(input_config)
+
+    assert ifname == "bogus3"
+    assert if_config.type == VintageNet.Technology.Null
+    assert if_config.reason =~ "unrecoverable error"
+  end
 end

--- a/test/vintage_net/interface_test.exs
+++ b/test/vintage_net/interface_test.exs
@@ -52,7 +52,9 @@ defmodule VintageNet.InterfaceTest do
       configure_and_wait(config)
       assert @ifname in VintageNet.configured_interfaces()
       :ok = VintageNet.deconfigure(@ifname)
-      assert %{type: VintageNet.Technology.Null} == VintageNet.get_configuration(@ifname)
+
+      assert %{type: VintageNet.Technology.Null, reason: "Interface deconfigured"} ==
+               VintageNet.get_configuration(@ifname)
 
       :ok = Interface.wait_until_configured(@ifname)
       refute @ifname in VintageNet.configured_interfaces()

--- a/test/vintage_net/technology/null_test.exs
+++ b/test/vintage_net/technology/null_test.exs
@@ -5,12 +5,13 @@ defmodule VintageNet.Technology.NullTest do
 
   test "normalizing null" do
     # Normalizing anything to Null should be Null
-    assert %{type: VintageNet.Technology.Null} == Null.normalize(%{})
+    assert %{type: VintageNet.Technology.Null, reason: ""} == Null.normalize(%{})
   end
 
   test "converting to raw config" do
     input = %{
-      type: VintageNet.Technology.Null
+      type: VintageNet.Technology.Null,
+      reason: "unit testing"
     }
 
     # Static IP support is not implemented. This is what is currently produced,

--- a/test/vintage_net/technology_test.exs
+++ b/test/vintage_net/technology_test.exs
@@ -1,0 +1,13 @@
+defmodule VintageNet.TechnologyTest do
+  use ExUnit.Case
+  doctest VintageNet.Technology
+  alias VintageNet.Technology
+
+  test "loading good configurations" do
+    assert VintageNetTest.TestTechnology ==
+             Technology.module_from_config!(%{
+               type: VintageNetTest.TestTechnology,
+               bogus: 0
+             })
+  end
+end

--- a/test/vintage_net_test.exs
+++ b/test/vintage_net_test.exs
@@ -146,17 +146,20 @@ defmodule VintageNetTest do
   test "persisted configurations get restored" do
     assert VintageNet.get_configuration("bogus0") == %{
              type: VintageNetTest.TestTechnology,
-             bogus: 0
+             bogus: 0,
+             normalize_was_called: true
            }
 
     assert VintageNet.get_configuration("bogus1") == %{
              type: VintageNetTest.TestTechnology,
-             bogus: 1
+             bogus: 1,
+             normalize_was_called: true
            }
 
     assert VintageNet.get_configuration("bogus2") == %{
              type: VintageNetTest.TestTechnology,
-             bogus: 2
+             bogus: 2,
+             normalize_was_called: true
            }
   end
 
@@ -176,7 +179,9 @@ defmodule VintageNetTest do
       assert File.exists?(path)
       :ok = VintageNet.reset_to_defaults("bogus1")
       refute File.exists?(path)
-      assert %{type: VintageNet.Technology.Null} == VintageNet.get_configuration("bogus1")
+
+      assert %{type: VintageNet.Technology.Null, reason: "No default configuration"} ==
+               VintageNet.get_configuration("bogus1")
     end
 
     test "overridden by a configuration" do
@@ -195,7 +200,9 @@ defmodule VintageNetTest do
       refute File.exists?(path)
       :ok = VintageNet.reset_to_defaults("unknown1")
       refute File.exists?(path)
-      assert %{type: VintageNet.Technology.Null} == VintageNet.get_configuration("unknown1")
+
+      assert %{type: VintageNet.Technology.Null, reason: "No default configuration"} ==
+               VintageNet.get_configuration("unknown1")
     end
   end
 


### PR DESCRIPTION
Previously, the configurations in the application environment and those persisted on the filesystem were kept unnormalized until used. You could see this by getting the configuration via the property table or via VintageNet.info.

This causes a couple problems. First, it was confusing since you'd get different views of the configuration depending on whether it was set at compile-time or run-time or restored. The second issue is that errors due to run-time evaluation could be deferred for when you'd find out about them.

This change normalizes the configurations on start and adds a reason field to the `Null` configuration. That way if you miss or don't see the error in the logs, you'll get a big message for why the interface wasn't configured when checking its configuration.

This change also addresses a minor problem of why `Null` configurations are set on interfaces since it can be set automatically on errors. If the user did it themselves via `VintageNet.deconfigure/2`, this makes it unambiguous.

Fixes #482 