### PR TITLE
Warn on `add_default_route` error instead of crashing

### DIFF
--- a/lib/vintage_net/route_manager.ex
+++ b/lib/vintage_net/route_manager.ex
@@ -344,7 +344,8 @@ defmodule VintageNet.RouteManager do
   end
 
   defp handle_insert({:default_route, ifname, default_gateway, metric, table_index}) do
-    :ok = IPRoute.add_default_route(ifname, default_gateway, metric, table_index)
+    IPRoute.add_default_route(ifname, default_gateway, metric, table_index)
+    |> warn_on_error("add_default_route")
   end
 
   defp handle_insert({:rule, table_index, address}) do


### PR DESCRIPTION
This PR fixes an issue I've encountered where an invalid static configuration that's shaped correctly can crash the route manager. To recreate the issue:

1. Take a static network config that shouldn't work, but looks good enough. I have been using:
```elixir
network_config = %{
  type: VintageNetEthernet,
  ipv4: %{
    method: :static,
    address: "10.42.0.82",
    netmask: "255.255.255.0",
    name_servers: ["8.8.8.8"],
    gateway: "192.168.0.1"
  }
}
```
In my case, the gateway address *could* be valid, but it's the entirely wrong subnet for my network.
2. Confirm that this config passes `VintageNet.configuration_valid?`. It also passes `VintageNet.Interface.to_raw_config`.
3. Attempt to apply the config. In my case `VintageNet.configure("eth0", network_config)`
4. A moment later, VintageNet will have crashed due to an inability to create a default route.

This PR allows for a more graceful recovery or second attempt, for example if trusting user input. 