### PR TITLE
Bulletproof force clearing IP addresses

### DIFF
--- a/lib/vintage_net/interfaces_monitor.ex
+++ b/lib/vintage_net/interfaces_monitor.ex
@@ -56,16 +56,15 @@ defmodule VintageNet.InterfacesMonitor do
 
   @impl GenServer
   def handle_call({:force_clear_ipv4_addresses, ifname}, _from, state) do
-    {ifindex, old_info} = get_by_ifname(state, ifname)
-    new_info = Info.delete_ipv4_addresses(old_info)
-
-    if old_info != new_info do
+    with {ifindex, old_info} <- get_by_ifname(state, ifname),
+         new_info = Info.delete_ipv4_addresses(old_info),
+         true <- old_info != new_info do
       new_info = Info.update_address_properties(new_info)
 
       new_state = %{state | interface_info: Map.put(state.interface_info, ifindex, new_info)}
       {:reply, :ok, new_state}
     else
-      {:reply, :ok, state}
+      _ -> {:reply, :ok, state}
     end
   end
 

--- a/test/vintage_net/interfaces_monitor_test.exs
+++ b/test/vintage_net/interfaces_monitor_test.exs
@@ -339,6 +339,10 @@ defmodule VintageNet.InterfacesMonitorTest do
     InterfacesMonitor.force_clear_ipv4_addresses("bogus0")
 
     refute_receive {VintageNet, ["interface", "bogus0", "addresses"], _anything, _anything2, %{}}
+
+    # This shouldn't crash
+    InterfacesMonitor.force_clear_ipv4_addresses("bogus1")
+    refute_receive _
   end
 
   defp get_interfaces() do


### PR DESCRIPTION
This was seen in the wild and probably due to a race with a bouncing
network connection. Crashing seems too harsh.
