### PR TITLE
Unconditionally terminate and delete technologies when done

### DIFF
--- a/lib/vintage_net/interface/supervisor.ex
+++ b/lib/vintage_net/interface/supervisor.ex
@@ -54,9 +54,8 @@ defmodule VintageNet.Interface.Supervisor do
   def clear_technology(ifname) do
     name = via_name(ifname)
 
-    with :ok <- Supervisor.terminate_child(name, :technology) do
-      Supervisor.delete_child(name, :technology)
-    end
+    _ = Supervisor.terminate_child(name, :technology)
+    _ = Supervisor.delete_child(name, :technology)
 
     :ok
   end


### PR DESCRIPTION
This fixes a Dialyzer warning and simplifies the code. The errors can be
ignored since there's nothing that can be done anyway.
