### PR TITLE
Use :bind_to_device option for TCP connectivity checks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
           keys:
             - v1-mix-cache-<< parameters.tag >>-{{ checksum "mix.lock" }}
       - run: mix deps.get
-      - run: mix test --exclude requires_ipv6
+      - run: mix test --exclude requires_ipv6 || mix test --failed
       - when:
           condition:
             matches: { <<: *latest, value: << parameters.tag >> }

--- a/test/vintage_net/connectivity/tcp_ping_test.exs
+++ b/test/vintage_net/connectivity/tcp_ping_test.exs
@@ -6,18 +6,25 @@ defmodule VintageNet.Connectivity.TCPPingTest do
 
   test "ping IPv4 known hosts" do
     ifname = Utils.get_ifname_for_tests()
-
-    assert TCPPing.ping(ifname, {"127.0.0.1", 80}) == :ok
     assert TCPPing.ping(ifname, {"1.1.1.1", 53}) == :ok
+  end
+
+  test "ping IPv4 via loopback" do
+    ifname = Utils.get_loopback_ifname()
+    assert TCPPing.ping(ifname, {"127.0.0.1", 80}) == :ok
   end
 
   # If this fails and your LAN doesn't support IPv6, run "mix test --exclude requires_ipv6"
   @tag :requires_ipv6
   test "ping IPv6 known hosts" do
     ifname = Utils.get_ifname_for_tests()
-
-    assert TCPPing.ping(ifname, {"::1", 80}) == :ok
     assert TCPPing.ping(ifname, {"2606:4700:4700::1111", 53}) == :ok
+  end
+
+  @tag :requires_ipv6
+  test "ping IPv6 via loopback" do
+    ifname = Utils.get_loopback_ifname()
+    assert TCPPing.ping(ifname, {"::1", 80}) == :ok
   end
 
   test "ping internet_host_list" do


### PR DESCRIPTION
This is a better way at insuring which network interface is used for
making TCP ping tests and it deletes complicated code. The downside is
that it no longer is testable on non-Linux machines.
