### PR TITLE
Support property_table v0.3.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -100,7 +100,7 @@ defmodule VintageNet.MixProject do
       {:beam_notify, "~> 1.0 or ~> 0.2.0"},
       {:gen_state_machine, "~> 2.0.0 or ~> 2.1.0 or ~> 3.0.0"},
       {:muontrap, "~> 1.0 or ~> 0.5.1 or ~> 0.6.0"},
-      {:property_table, "~> 0.2.0"},
+      {:property_table, "~> 0.2.0 or ~> 0.3.0"},
       # Build dependencies
       {:credo, "~> 1.2", only: :test, runtime: false},
       {:credo_binary_patterns, "~> 0.2.2", only: :test, runtime: false},

--- a/mix.lock
+++ b/mix.lock
@@ -16,5 +16,5 @@
   "makeup_erlang": {:hex, :makeup_erlang, "1.0.1", "c7f58c120b2b5aa5fd80d540a89fdf866ed42f1f3994e4fe189abebeab610839", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "8a89a1eeccc2d798d6ea15496a6e4870b75e014d1af514b1b71fa33134f57814"},
   "muontrap": {:hex, :muontrap, "1.5.0", "bf5c273872379968615a39974458328209ac97fa1f588396192131ff973d1ca2", [:make, :mix], [{:elixir_make, "~> 0.6", [hex: :elixir_make, repo: "hexpm", optional: false]}], "hexpm", "daf605e877f60b5be9215e3420d7971fc468677b29921e40915b15fd928273d4"},
   "nimble_parsec": {:hex, :nimble_parsec, "1.4.0", "51f9b613ea62cfa97b25ccc2c1b4216e81df970acd8e16e8d1bdc58fef21370d", [:mix], [], "hexpm", "9c565862810fb383e9838c1dd2d7d2c437b3d13b267414ba6af33e50d2d1cf28"},
-  "property_table": {:hex, :property_table, "0.2.6", "41fb5e94cabc360827213abcf0b2ae255a22f834f86828df63001fccbaf3d319", [:mix], [], "hexpm", "7545a31384eb9e98da91a54cfa4ad7cb8b38ba556d6b7051c3f7d9f9f4caf567"},
+  "property_table": {:hex, :property_table, "0.3.0", "aa51e0eb5e9789edb45e1048223f7f30ffd4e4dd0e3bd4924d8fa22d7800f9f6", [:mix], [], "hexpm", "696289fe01a2d685eb460e5440e64736ec8a07d8e4748e2d573b12b590b931e3"},
 }


### PR DESCRIPTION
The backwards incompatible changes from v0.2 to v0.3 don't affect
VintageNet at all, so allow both versions.
