### PR TITLE
Request WPAD via DHCP option 252

### DIFF
--- a/lib/vintage_net/ip/ipv4_config.ex
+++ b/lib/vintage_net/ip/ipv4_config.ex
@@ -13,7 +13,18 @@ defmodule VintageNet.IP.IPv4Config do
 
   * `:method` - `:dhcp`, `:static`, or `:disabled`
 
-  The `:dhcp` method currently has no additional fields.
+  The `:dhcp` method supports the following optional field:
+
+  * `:dhcp_request_options` - a list of additional DHCP option names (strings) to
+    request from the DHCP server beyond udhcpc's defaults. Each entry is passed
+    through to udhcpc as `-O <entry>`. Either symbolic names ("wpad", "sipsrv")
+    or numeric option codes ("252") are accepted; what's recognized depends on
+    the busybox version in use. Defaults to `[]`. Values that the DHCP server
+    returns are parsed by `VintageNet.DHCP.Options` and exposed via the
+    `["interface", ifname, "dhcp_options"]` property. Requesting additional
+    options changes the contents of the DHCP request, which some networks use
+    to classify or segment clients (for example, fingerprint-based VLAN
+    assignment), so only opt in to options you actually need.
 
   The `:static` method uses the following fields:
 
@@ -46,7 +57,13 @@ defmodule VintageNet.IP.IPv4Config do
     Map.put(config, :ipv4, %{method: :dhcp})
   end
 
-  defp normalize_by_method(%{method: :dhcp}), do: %{method: :dhcp}
+  defp normalize_by_method(%{method: :dhcp} = ipv4) do
+    case Map.get(ipv4, :dhcp_request_options) do
+      nil -> %{method: :dhcp}
+      options -> %{method: :dhcp, dhcp_request_options: normalize_dhcp_request_options(options)}
+    end
+  end
+
   defp normalize_by_method(%{method: :disabled}), do: %{method: :disabled}
 
   defp normalize_by_method(%{method: :static} = ipv4) do
@@ -91,6 +108,22 @@ defmodule VintageNet.IP.IPv4Config do
   end
 
   defp normalize_name_servers(config), do: config
+
+  defp normalize_dhcp_request_options(options) when is_list(options) do
+    Enum.map(options, fn
+      option when is_binary(option) ->
+        option
+
+      other ->
+        raise ArgumentError,
+              "ipv4.dhcp_request_options must contain strings, got: #{inspect(other)}"
+    end)
+  end
+
+  defp normalize_dhcp_request_options(other) do
+    raise ArgumentError,
+          "ipv4.dhcp_request_options must be a list of strings, got: #{inspect(other)}"
+  end
 
   defp get_prefix_length(%{prefix_length: prefix_length}), do: prefix_length
 
@@ -148,6 +181,11 @@ defmodule VintageNet.IP.IPv4Config do
 
     hostname = config[:hostname] || get_hostname()
 
+    request_option_args =
+      config.ipv4
+      |> Map.get(:dhcp_request_options, [])
+      |> Enum.flat_map(&["-O", &1])
+
     new_child_specs =
       child_specs ++
         [
@@ -156,15 +194,16 @@ defmodule VintageNet.IP.IPv4Config do
              [
                ifname: ifname,
                command: "udhcpc",
-               args: [
-                 "-f",
-                 "-i",
-                 ifname,
-                 "-x",
-                 "hostname:#{hostname}",
-                 "-s",
-                 BEAMNotify.bin_path()
-               ],
+               args:
+                 [
+                   "-f",
+                   "-i",
+                   ifname,
+                   "-x",
+                   "hostname:#{hostname}",
+                   "-s",
+                   BEAMNotify.bin_path()
+                 ] ++ request_option_args,
                opts:
                  Command.add_muon_options(
                    stderr_to_stdout: true,

--- a/test/support/utils.ex
+++ b/test/support/utils.ex
@@ -10,8 +10,11 @@ defmodule VintageNetTest.Utils do
     Application.get_all_env(:vintage_net)
   end
 
-  @spec udhcpc_child_spec(VintageNet.ifname(), String.t()) :: Supervisor.child_spec()
-  def udhcpc_child_spec(ifname, hostname) do
+  @spec udhcpc_child_spec(VintageNet.ifname(), String.t(), [String.t()]) ::
+          Supervisor.child_spec()
+  def udhcpc_child_spec(ifname, hostname, dhcp_request_options \\ []) do
+    request_option_args = Enum.flat_map(dhcp_request_options, &["-O", &1])
+
     %{
       id: :udhcpc,
       start:
@@ -20,15 +23,16 @@ defmodule VintageNetTest.Utils do
            [
              ifname: ifname,
              command: "udhcpc",
-             args: [
-               "-f",
-               "-i",
-               ifname,
-               "-x",
-               "hostname:#{hostname}",
-               "-s",
-               BEAMNotify.bin_path()
-             ],
+             args:
+               [
+                 "-f",
+                 "-i",
+                 ifname,
+                 "-x",
+                 "hostname:#{hostname}",
+                 "-s",
+                 BEAMNotify.bin_path()
+               ] ++ request_option_args,
              opts: [
                stderr_to_stdout: true,
                log_output: :debug,

--- a/test/vintage_net/dhcp/options_test.exs
+++ b/test/vintage_net/dhcp/options_test.exs
@@ -40,4 +40,15 @@ defmodule VintageNet.DHCP.OptionsTest do
 
     assert expected_options == Options.udhcpc_to_options(info)
   end
+
+  test "translates the WPAD option (252) into :wpad" do
+    info = %{
+      "interface" => "eth0",
+      "ip" => "192.168.1.245",
+      "wpad" => "http://wpad.example/wpad.dat"
+    }
+
+    assert %{wpad: "http://wpad.example/wpad.dat"} =
+             Options.udhcpc_to_options(info)
+  end
 end

--- a/test/vintage_net/ip/ipv4_config_test.exs
+++ b/test/vintage_net/ip/ipv4_config_test.exs
@@ -101,6 +101,66 @@ defmodule VintageNet.IP.IPv4ConfigTest do
     assert expected == IPv4Config.add_config(initial_raw_config, input, default_opts())
   end
 
+  test "ipv4 dhcp default normalizes without :dhcp_request_options" do
+    # Unspecified :dhcp_request_options should round-trip as a bare :dhcp config,
+    # not gain an empty list — preserves the existing normalized shape.
+    assert %{ipv4: %{method: :dhcp}} ==
+             IPv4Config.normalize(%{ipv4: %{method: :dhcp}})
+  end
+
+  test "ipv4 dhcp preserves :dhcp_request_options through normalize" do
+    assert %{ipv4: %{method: :dhcp, dhcp_request_options: ["wpad", "sipsrv"]}} ==
+             IPv4Config.normalize(%{
+               ipv4: %{method: :dhcp, dhcp_request_options: ["wpad", "sipsrv"]}
+             })
+  end
+
+  test "ipv4 dhcp rejects non-string entries in :dhcp_request_options" do
+    assert_raise ArgumentError, fn ->
+      IPv4Config.normalize(%{ipv4: %{method: :dhcp, dhcp_request_options: [:wpad]}})
+    end
+  end
+
+  test "ipv4 dhcp rejects non-list :dhcp_request_options" do
+    assert_raise ArgumentError, fn ->
+      IPv4Config.normalize(%{ipv4: %{method: :dhcp, dhcp_request_options: "wpad"}})
+    end
+  end
+
+  test "ipv4 dhcp emits -O args when :dhcp_request_options is set" do
+    input =
+      %{
+        hostname: "unit_test",
+        ipv4: %{method: :dhcp, dhcp_request_options: ["wpad"]}
+      }
+      |> IPv4Config.normalize()
+
+    initial_raw_config = %VintageNet.Interface.RawConfig{
+      ifname: "eth0",
+      source_config: input,
+      type: UnitTest,
+      required_ifnames: ["eth0"]
+    }
+
+    expected = %VintageNet.Interface.RawConfig{
+      type: UnitTest,
+      ifname: "eth0",
+      source_config: input,
+      required_ifnames: ["eth0"],
+      child_specs: [
+        udhcpc_child_spec("eth0", "unit_test", ["wpad"]),
+        {VintageNet.Connectivity.InternetChecker, "eth0"}
+      ],
+      down_cmds: [
+        {:run_ignore_errors, "ip", ["addr", "flush", "dev", "eth0", "label", "eth0"]},
+        {:run, "ip", ["link", "set", "eth0", "down"]}
+      ],
+      up_cmds: [{:run, "ip", ["link", "set", "eth0", "up"]}]
+    }
+
+    assert expected == IPv4Config.add_config(initial_raw_config, input, default_opts())
+  end
+
   test "ipv4 static config with a default gateway" do
     input =
       %{


### PR DESCRIPTION
Adds `-O wpad` to the udhcpc invocation so the DHCP server is asked for option 252 (Web Proxy Auto-Discovery). The parsing side already mapped this to `:wpad` inside `dhcp_options`, but without explicitly requesting the option busybox udhcpc never received it. The value now surfaces in the existing `["interface", ifname, "dhcp_options"]` property so a companion proxy library can subscribe and react.