### PR TITLE
Fix resolv.conf permissions for normal users

### DIFF
--- a/lib/vintage_net/name_resolver.ex
+++ b/lib/vintage_net/name_resolver.ex
@@ -131,8 +131,9 @@ defmodule VintageNet.NameResolver do
          entries: entries,
          additional_name_servers: additional_name_servers
        }) do
-    # Update the resolv.conf file
+    # Update the resolv.conf file and ensure world readable for other programs
     File.write!(path, ResolvConf.to_config(entries, additional_name_servers))
+    File.chmod!(path, 0o644)
 
     # Let VintageNet users know the latest
     PropertyTable.put(


### PR DESCRIPTION
Without this change, a system running with a 077 umask creates
unreadable resolv.conf files for normal users. This breaks DNS for them.
DNS should work for everyone or at least everyone should be able to know
the current DNS server IP addresses. Since the permissions are more
permissive than default, there's no race that could be exploited.
