### PR TITLE
Update HexDoc URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ SPDX-License-Identifier: CC-BY-4.0
 ![VintageNet Logo](assets/vintage_net.png)
 
 [![Hex version](https://img.shields.io/hexpm/v/vintage_net.svg "Hex version")](https://hex.pm/packages/vintage_net)
-[![API docs](https://img.shields.io/hexpm/v/vintage_net.svg?label=hexdocs "API docs")](https://hexdocs.pm/vintage_net/VintageNet.html)
+[![API docs](https://img.shields.io/hexpm/v/vintage_net.svg?label=hexdocs "API docs")](https://vintage-net.hexdocs.pm/VintageNet.html)
 [![CircleCI](https://dl.circleci.com/status-badge/img/gh/nerves-networking/vintage_net/tree/main.svg?style=svg)](https://dl.circleci.com/status-badge/redirect/gh/nerves-networking/vintage_net/tree/main)
 [![REUSE status](https://api.reuse.software/badge/github.com/nerves-networking/vintage_net)](https://api.reuse.software/info/github.com/nerves-networking/vintage_net)
 
@@ -75,7 +75,7 @@ config :vintage_net,
   ]
 ```
 
-For more variants, see the [VintageNet Cookbook](https://hexdocs.pm/vintage_net/cookbook.html). It covers:
+For more variants, see the [VintageNet Cookbook](https://vintage-net.hexdocs.pm/cookbook.html). It covers:
 
 - Compile-time vs. run-time
 - Static IPs

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -39,7 +39,7 @@ configuration from below.
 ### Run-time (IEx)
 
 Call
-[`VintageNet.configure`](https://hexdocs.pm/vintage_net/VintageNet.html#configure/3)
+[`VintageNet.configure`](https://vintage-net.hexdocs.pm/VintageNet.html#configure/3)
 like this:
 
 ```elixir
@@ -140,7 +140,7 @@ VintageNet.configure("eth0", %{
 <!-- tabs-close -->
 
 See
-[`VintageNet.IP.IPv4Config`](https://hexdocs.pm/vintage_net/VintageNet.IP.IPv4Config.html)
+[`VintageNet.IP.IPv4Config`](https://vintage-net.hexdocs.pm/VintageNet.IP.IPv4Config.html)
 for other options. If you're interfacing with other Erlang and Elixir libraries,
 you may find passing IP tuples more convenient than passing strings. That works
 too.
@@ -738,7 +738,7 @@ VintageNet.configure("mesh0", mesh0_config)
 
 For sharing your WAN connection (e.g. internet access) with other networks
 `iptables` must be installed. Currently this means building a [custom nerves
-system](https://hexdocs.pm/nerves/customizing-systems.html). Once this is done
+system](https://nerves.hexdocs.pm/customizing-systems.html). Once this is done
 the following commands need to be called on each boot:
 
 ```elixir

--- a/mix.exs
+++ b/mix.exs
@@ -173,7 +173,7 @@ defmodule VintageNet.MixProject do
           vintage_net is incompatible with #{inspect(bad_dep)}.
 
           Please remove #{inspect(bad_dep)} from your project's mix dependencies. See
-          https://hexdocs.pm/vintage_net/readme.html#installation for help.
+          https://vintage-net.hexdocs.pm/readme.html#installation for help.
           """)
         end
       end)


### PR DESCRIPTION
Migrates HexDocs URLs to the 2026 format using hex_url_migrator.

<details>
<summary>⚠️ URL verification warnings from <code>hex_url_migrator --verify</code></summary>

```
❌ Verification failed for https://vintage-net.hexdocs.pm/VintageNet.html): Status 404
❌ Verification failed for https://vintage-net.hexdocs.pm/cookbook.html): Status 404
❌ Verification failed for https://vintage-net.hexdocs.pm/VintageNet.IP.IPv4Config.html): Status 404
❌ Verification failed for https://nerves.hexdocs.pm/customizing-systems.html): Status 301
⚠️ Verification finished: 2 success, 4 failure(s).
```

_Reported by the migrator's verifier. Note that `301`s are typically redirects (the target exists) and a trailing `)` is a markdown-link parsing artifact. Please review before merging._
</details>