### PR TITLE
Don't crash if resolv.conf can't be world readable

### DIFF
--- a/lib/vintage_net/name_resolver.ex
+++ b/lib/vintage_net/name_resolver.ex
@@ -131,9 +131,11 @@ defmodule VintageNet.NameResolver do
          entries: entries,
          additional_name_servers: additional_name_servers
        }) do
-    # Update the resolv.conf file and ensure world readable for other programs
+    # Update the resolv.conf file
     File.write!(path, ResolvConf.to_config(entries, additional_name_servers))
-    File.chmod!(path, 0o644)
+
+    # Best effort change permissions to make world readable if not
+    _ = File.chmod(path, 0o644)
 
     # Let VintageNet users know the latest
     PropertyTable.put(


### PR DESCRIPTION
Even though /etc/resolv.conf really needs to be world readable to be
usable, it's not always possible to change permissions. Therefore, make
it best effort since crashing is worse than not changing permissions
and it's possible that the file is readable enough.

This fixes crashes when using vintage_net in unit tests.
