### PR TITLE
Add captive_portal DHCP server option (RFC 8910)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ SPDX-License-Identifier: CC0-1.0
 
 This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+* New features
+  * Add a `:captive_portal` DHCP server option that advertises a captive portal
+    API endpoint to clients per [RFC 8910](https://www.rfc-editor.org/info/rfc8910).
+    This is useful when running an access point that presents a captive portal.
+    Set it under `dhcpd.options`, e.g.
+    `options: %{captive_portal: "https://192.168.24.1/portal.json"}`.
+
 ## [v0.13.12] - 2026-06-07
 
 * Fixes

--- a/lib/vintage_net/ip/dhcpd_config.ex
+++ b/lib/vintage_net/ip/dhcpd_config.ex
@@ -22,6 +22,7 @@ defmodule VintageNet.IP.DhcpdConfig do
   * `:auto_time` - The time period at which udhcpd will write out leases file.
   * `:static_leases` - list of `{mac_address, ip_address}`
   * `:options` - a map DHCP response options to set. Such as:
+    * `:captive_portal` - STRING - [0x72] URI of the captive portal API (RFC 8910)
     * `:dns` - IP_LIST
     * `:domain` -  STRING - [0x0f] client's domain suffix
     * `:hostname` - STRING
@@ -35,6 +36,12 @@ defmodule VintageNet.IP.DhcpdConfig do
   > Options may also be passed in as integers. These are passed directly to the DHCP server
   > and their values are strings that are not interpreted by VintageNet. Use this to support
   > custom DHCP header options. For more details on DHCP response options see RFC 2132
+
+  > #### :captive_portal {: .info}
+  > The `:captive_portal` option advertises a captive portal API endpoint to clients per
+  > [RFC 8910](https://www.rfc-editor.org/info/rfc8910). It's useful when running an access
+  > point that presents a captive portal. Set it to the URI that clients should query, e.g.
+  > `options: %{captive_portal: "https://192.168.24.1/portal.json"}`.
 
   ## Example
   ```
@@ -71,6 +78,12 @@ defmodule VintageNet.IP.DhcpdConfig do
   @string_options [:hostname, :domain]
   @string_list_options [:search]
   @list_options @ip_list_options ++ @string_list_options
+
+  # RFC 8910 Captive-Portal option. busybox udhcpd doesn't know this option by
+  # name, so it's emitted by its numeric code with the URI quoted. Quoting is
+  # required: an unquoted value for a numeric option is interpreted as a hex
+  # string by udhcpd.
+  @captive_portal_option_code 114
 
   @doc """
   Normalize the DHCPD parameters in a configuration.
@@ -149,6 +162,10 @@ defmodule VintageNet.IP.DhcpdConfig do
        when int_option in @int_options and
               is_integer(value) do
     {int_option, value}
+  end
+
+  defp normalize_option({:captive_portal, uri}) do
+    {:captive_portal, to_string(uri)}
   end
 
   defp normalize_option({string_option, string})
@@ -293,6 +310,12 @@ defmodule VintageNet.IP.DhcpdConfig do
 
   defp to_udhcpd_option_string({option, string}) when option in @string_options do
     [to_string(option), " ", string]
+  end
+
+  defp to_udhcpd_option_string({:captive_portal, uri}) do
+    # Emit by numeric code with a quoted URI so udhcpd treats it as a string
+    # rather than a hex value.
+    [to_string(@captive_portal_option_code), " \"", uri, "\""]
   end
 
   defp to_udhcpd_option_string({other_option, string}) when is_integer(other_option) do

--- a/test/vintage_net/ip/dhcpd_config_test.exs
+++ b/test/vintage_net/ip/dhcpd_config_test.exs
@@ -94,6 +94,57 @@ defmodule VintageNet.IP.DhcpdConfigTest do
     assert normalized_config == DhcpdConfig.normalize(config)
   end
 
+  test "dhcpd normalizes the captive_portal option (RFC 8910)" do
+    config = %{
+      dhcpd: %{
+        start: "192.168.1.2",
+        end: "192.168.1.100",
+        options: %{
+          captive_portal: "https://192.168.1.1/portal.json"
+        }
+      }
+    }
+
+    normalized_config = %{
+      dhcpd: %{
+        start: {192, 168, 1, 2},
+        end: {192, 168, 1, 100},
+        options: %{captive_portal: "https://192.168.1.1/portal.json"}
+      }
+    }
+
+    assert normalized_config == DhcpdConfig.normalize(config)
+  end
+
+  test "dhcpd emits a quoted numeric opt 114 for captive_portal" do
+    input =
+      %{
+        dhcpd: %{
+          start: "192.168.1.2",
+          end: "192.168.1.100",
+          options: %{
+            captive_portal: "https://192.168.1.1/portal.json"
+          }
+        }
+      }
+      |> DhcpdConfig.normalize()
+
+    initial_raw_config = %VintageNet.Interface.RawConfig{
+      ifname: "wlan0",
+      source_config: input,
+      type: UnitTest,
+      required_ifnames: ["wlan0"]
+    }
+
+    opts = [tmpdir: "tmpdir", bin_udhcpd: "udhcpd"]
+
+    result = DhcpdConfig.add_config(initial_raw_config, input, opts)
+
+    {_path, contents} = List.keyfind(result.files, "tmpdir/udhcpd.conf.wlan0", 0)
+
+    assert contents =~ ~s(opt 114 "https://192.168.1.1/portal.json")
+  end
+
   test "normalize fixes item passed instead of list" do
     # Pass an IP address rather than a list for the DNS option
     config = %{


### PR DESCRIPTION
## Summary

Adds a `:captive_portal` option to the DHCP server config (`dhcpd.options`) that advertises a captive portal API endpoint to clients per [RFC 8910](https://www.rfc-editor.org/info/rfc8910). This is useful when running an access point that presents a captive portal.

```elixir
dhcpd: %{
  start: {192, 168, 24, 2},
  end: {192, 168, 24, 100},
  options: %{captive_portal: "https://192.168.24.1/portal.json"}
}
```

## Why a dedicated option instead of the raw integer option?

RFC 8910 is DHCP option 114 (0x72), and the value is a URI string. busybox udhcpd doesn't know this option by name, so it has to be emitted by its numeric code. The catch is in how busybox parses numeric options (`udhcp_str2optset` in `networking/udhcp/common.c`): a numeric option is treated as `OPTION_BIN` and is only stored as a string when the value is **quoted** — unquoted, it's parsed as a hex string and the URI is mangled.

The existing raw integer-option path emits values unquoted (`opt 114 https://...`), so it can't express an RFC 8910 URI correctly. This option emits `opt 114 "https://..."` with the quotes, which busybox stores as a string.

## Changes

- `lib/vintage_net/ip/dhcpd_config.ex` — normalize + emit the `:captive_portal` option; moduledoc entry and info callout.
- `test/vintage_net/ip/dhcpd_config_test.exs` — normalization test and an end-to-end test asserting the rendered `udhcpd.conf` contains `opt 114 "https://…"`.
- `CHANGELOG.md` — Unreleased entry.

## Testing

`mix test test/vintage_net/ip/dhcpd_config_test.exs` passes (8 tests). The only failures in the full suite are the pre-existing network-dependent `tcp_ping_test.exs` cases, which also fail on the unmodified baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)